### PR TITLE
Add admin dashboard for reviewing new artwork metadata

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,10 +6,11 @@ A FastAPI-based web application for displaying and managing an artwork gallery. 
 
 - Display artwork images in a responsive gallery layout
 - Support for multiple image formats (JPG, PNG, GIF, WEBP, SVG, BMP, TIFF)
-- Image metadata support including title, description, and technical details
+- Image metadata support including title and description
 - Static file serving for images and CSS
 - Templated HTML using Jinja2
 - Logging system for debugging and monitoring
+- Admin dashboard for uploading images, detecting new files, and editing metadata before publication
 
 ## Prerequisites
 
@@ -44,9 +45,8 @@ A FastAPI-based web application for displaying and managing an artwork gallery. 
 ```
 project_root/ 
 ├── main.py # Main application file
-├── static/ # Static files directory 
-│  ├── images/ # Directory for artwork images 
-│  └── css/ # CSS stylesheets 
+├── Static/ # Static files directory
+│  ├── images/ # Directory for artwork images
 │  └── css/ # CSS stylesheets
 └── templates/ # HTML templates 
       └── index.html # Main gallery template
@@ -54,11 +54,11 @@ project_root/
 
 ## Configuration
 
-1. Place your artwork images in the `static/images/` directory
+1. Place your artwork images in the `Static/images/` directory
 2. (Optional) Create JSON metadata files for images with the same name as the image file:
    ```
-   static/images/artwork1.jpg
-   static/images/artwork1.json
+   Static/images/artwork1.jpg
+   Static/images/artwork1.json
    ```
 
 ## Running the Application
@@ -73,17 +73,27 @@ project_root/
 
 ## Usage
 
-- Add images to the `static/images/` directory
-- Create corresponding JSON files for custom metadata (optional)
+- Add images to the `Static/images/` directory
+- (Optional) create corresponding JSON files for custom metadata
+- If no JSON exists, the app will read embedded EXIF captions and titles
 - Access the gallery through your web browser
 - Images will be automatically displayed with their metadata
+
+### Admin dashboard
+
+- Navigate to `http://127.0.0.1:8000/admin` to open the administrative tools
+- Drag-and-drop or browse to upload new artwork files (image formats or JSON sidecars)
+- Provide an absolute server path to import images that already exist on disk
+- Newly detected files appear in a review queue where you can inspect thumbnails and detected metadata
+- Selecting **Review details** opens a form that lets you edit the title and description that will be saved to the JSON sidecar file
+- Once metadata is saved, the entry is marked as reviewed and removed from the pending list
 
 ## Development
 
 - The `--reload` flag enables auto-reload on code changes
 - Logging is configured for debugging
 - Templates can be modified in the `templates` directory
-- Static files (CSS, images) are served from the `static` directory
+- Static files (CSS, images) are served from the `Static` directory on disk and mounted at `/static` in the application
 
 ## License
 

--- a/Static/css/styles.css
+++ b/Static/css/styles.css
@@ -89,18 +89,21 @@ main {
     background-color: #eee; /* Light background color while image is loading */
 }
 
-/* Artwork name styling */
-.artwork-name {
+/* Artwork title styling */
+.artwork-title {
+    font-size: 1em;
+    font-weight: 600;
+    color: #495057;
+    margin: 0.5rem 0 0;
+    word-wrap: break-word;
+}
+
+/* Artwork description styling */
+.artwork-description {
     font-size: 0.9em;
-    color: #6c757d; /* Muted grey color for filename */
-    margin-top: auto; /* Push filename to the bottom if extra space */
-    margin-bottom: 0; /* Remove default paragraph margin */
-    /* Prevent long filenames from breaking layout */
-    word-wrap: break-word; /* Allow breaking long words */
-    white-space: nowrap; /* Keep filename on one line initially */
-    overflow: hidden; /* Hide overflow */
-    text-overflow: ellipsis; /* Add ellipsis (...) if text overflows */
-    padding-top: 0.5rem; /* Add some space above the text */
+    color: #6c757d;
+    margin: 0.25rem 0 0;
+    word-wrap: break-word;
 }
 
 /* Message shown when no artwork is found */
@@ -125,6 +128,302 @@ footer {
     flex-shrink: 0; /* Prevent footer from shrinking */
 }
 
+/* Reusable button styling */
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    padding: 0.55rem 1rem;
+    border-radius: 6px;
+    background-color: #495057;
+    color: #ffffff;
+    text-decoration: none;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+.button:hover,
+.button:focus {
+    background-color: #343a40;
+    transform: translateY(-1px);
+}
+
+.button.secondary {
+    background-color: #ced4da;
+    color: #212529;
+}
+
+.button.secondary:hover,
+.button.secondary:focus {
+    background-color: #adb5bd;
+}
+
+/* Admin layout */
+.admin-page header {
+    text-align: center;
+}
+
+.admin-subheading {
+    color: #6c757d;
+    margin: 0.5rem auto 0;
+    max-width: 720px;
+}
+
+.admin-nav {
+    margin-top: 1rem;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.admin-container {
+    display: grid;
+    grid-template-columns: minmax(280px, 1fr) minmax(0, 1.5fr);
+    gap: 2rem;
+}
+
+.admin-container.single {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.admin-panel {
+    background-color: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+.panel-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.panel-description {
+    margin-top: 0.5rem;
+    color: #6c757d;
+    line-height: 1.5;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.5rem;
+    padding: 0.25rem 0.75rem;
+    background-color: #343a40;
+    color: #ffffff;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    margin-left: 0.5rem;
+}
+
+.dropzone {
+    border: 2px dashed #adb5bd;
+    border-radius: 12px;
+    padding: 2rem 1rem;
+    text-align: center;
+    background-color: #fdfdfe;
+    transition: border-color 0.2s ease-in-out, background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+}
+
+.dropzone.is-dragover {
+    background-color: #e7f5ff;
+    border-color: #339af0;
+    transform: translateY(-2px);
+}
+
+.dropzone-icon {
+    width: 48px;
+    height: 48px;
+    color: #339af0;
+    margin-bottom: 0.75rem;
+}
+
+.supported-formats {
+    color: #6c757d;
+    font-size: 0.9rem;
+    margin-top: 0.75rem;
+}
+
+.path-form {
+    margin-top: 2rem;
+}
+
+.path-input-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+.path-input-row input[type="text"] {
+    flex: 1 1 240px;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid #ced4da;
+    border-radius: 6px;
+    font-size: 1rem;
+    box-sizing: border-box;
+}
+
+.pending-list {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.pending-card {
+    display: flex;
+    gap: 1rem;
+    border: 1px solid #dee2e6;
+    border-radius: 10px;
+    padding: 1rem;
+    background-color: #fff;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.pending-thumb img {
+    width: 120px;
+    height: 90px;
+    object-fit: cover;
+    border-radius: 6px;
+    border: 1px solid #dee2e6;
+}
+
+.pending-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.filename {
+    font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.9rem;
+    color: #868e96;
+}
+
+.description {
+    font-size: 0.95rem;
+    color: #495057;
+}
+
+.description.empty {
+    color: #adb5bd;
+    font-style: italic;
+}
+
+.empty-state {
+    text-align: center;
+    color: #868e96;
+    padding: 1.5rem;
+    border: 1px dashed #dee2e6;
+    border-radius: 8px;
+}
+
+.feedback {
+    max-width: 1200px;
+    margin: 1rem auto 0;
+    padding: 0.85rem 1rem;
+    border-radius: 8px;
+    font-weight: 600;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.feedback.success {
+    background-color: #d3f9d8;
+    color: #2b8a3e;
+    border: 1px solid #b2f2bb;
+}
+
+.feedback.error {
+    background-color: #ffe3e3;
+    color: #c92a2a;
+    border: 1px solid #ffa8a8;
+}
+
+.preview-wrapper {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+}
+
+.preview-image {
+    width: 100%;
+    max-width: 420px;
+    border-radius: 10px;
+    border: 1px solid #dee2e6;
+}
+
+.preview-meta {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.preview-meta dt {
+    font-weight: 600;
+    color: #495057;
+}
+
+.preview-meta dd {
+    margin: 0.25rem 0 0;
+    color: #6c757d;
+    word-break: break-word;
+}
+
+.metadata-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    margin-top: 1rem;
+}
+
+.form-field label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.form-field input,
+.form-field textarea {
+    width: 100%;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid #ced4da;
+    border-radius: 6px;
+    font-size: 1rem;
+    box-sizing: border-box;
+    font-family: inherit;
+}
+
+.form-field textarea {
+    resize: vertical;
+    min-height: 160px;
+}
+
+.form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Media query for smaller screens (e.g., mobile phones) */
 @media (max-width: 600px) {
     header h1 {
@@ -141,11 +440,31 @@ footer {
     .artwork-item {
         padding: 0.75rem; /* Reduce padding inside items */
     }
-    .artwork-name {
-        font-size: 0.8em; /* Smaller font for filename */
+    .artwork-title {
+        font-size: 0.9em; /* Smaller font for title */
     }
     footer {
         padding: 1rem 0.5rem;
         font-size: 0.8em;
+    }
+    .admin-container {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .pending-card {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+    .pending-thumb img {
+        width: 100%;
+        max-width: 320px;
+        height: auto;
+    }
+    .form-actions {
+        justify-content: stretch;
+    }
+    .form-actions .button,
+    .form-actions .button.secondary {
+        flex: 1 1 45%;
     }
 }

--- a/main.py
+++ b/main.py
@@ -1,19 +1,53 @@
 # main.py
 import os
+import json
+import asyncio
+import shutil
+import threading
+import time
+from contextlib import suppress
 from pathlib import Path
-from fastapi import FastAPI, Request
+from typing import Any, Dict, List
+
+from fastapi import (
+    FastAPI,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    UploadFile,
+)
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from starlette import status
+from PIL import Image, ExifTags
 import logging # Import logging
 
 # --- Configuration ---
 # Get the directory where this script is located
 BASE_DIR = Path(__file__).resolve().parent
 # Define directories relative to the base directory
-STATIC_DIR = BASE_DIR / "static"
+# Use the on-disk directory name with the expected capitalization.
+# Static files are served from the URL path `/static`, but the folder in
+# the repository is named with a capital "S".
+STATIC_DIR = BASE_DIR / "Static"
 IMAGES_DIR = STATIC_DIR / "images"
 TEMPLATES_DIR = BASE_DIR / "templates"
+MANIFEST_PATH = STATIC_DIR / "images_manifest.json"
+
+ALLOWED_IMAGE_EXTENSIONS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".webp",
+    ".svg",
+    ".bmp",
+    ".tiff",
+}
+
+POLL_INTERVAL_SECONDS = 5
 
 # Create necessary directories if they don't exist
 # parents=True creates any necessary parent directories
@@ -30,9 +64,9 @@ logger = logging.getLogger(__name__)
 # --- FastAPI App Setup ---
 app = FastAPI(title="Artwork Gallery")
 
-# Mount the 'static' directory. This makes files under 'static/'
-# accessible via URLs starting with '/static'. For example,
-# '/static/images/my_art.jpg' will serve the file 'static/images/my_art.jpg'.
+# Mount the Static directory on the '/static' URL path. This makes files
+# under 'Static/' accessible via URLs starting with '/static'. For example,
+# '/static/images/my_art.jpg' will serve the file 'Static/images/my_art.jpg'.
 # The 'name="static"' allows generating URLs using url_for('static', path=...) in templates
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
@@ -40,36 +74,207 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 # directory to render responses.
 templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
+manifest_lock = threading.Lock()
+
+
+def _sanitize_filename(filename: str) -> str:
+    """Return a safe filename without directory traversal."""
+    return Path(filename).name
+
+
+def _allowed_image(filename: str) -> bool:
+    return Path(filename).suffix.lower() in ALLOWED_IMAGE_EXTENSIONS
+
+
+def _load_manifest() -> Dict[str, Dict[str, Any]]:
+    if MANIFEST_PATH.exists():
+        try:
+            return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            logger.warning("Invalid manifest JSON, resetting: %s", exc)
+    return {}
+
+
+def _save_manifest(manifest: Dict[str, Dict[str, Any]]) -> None:
+    MANIFEST_PATH.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _ensure_sidecar(image_path: Path, metadata: Dict[str, Any]) -> None:
+    """Ensure a JSON sidecar exists for the provided image."""
+    json_path = image_path.with_suffix(".json")
+    if json_path.exists():
+        return
+    sidecar_data = {
+        "title": metadata.get("title") or image_path.stem,
+        "description": metadata.get("description", ""),
+    }
+    json_path.write_text(
+        json.dumps(sidecar_data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _write_sidecar(image_path: Path, metadata: Dict[str, Any]) -> None:
+    json_path = image_path.with_suffix(".json")
+    json_path.write_text(
+        json.dumps(metadata, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _set_review_status(filename: str, reviewed: bool) -> None:
+    with manifest_lock:
+        manifest = _load_manifest()
+        entry = manifest.get(filename)
+        if entry is None:
+            entry = {"reviewed": reviewed, "detected_at": time.time()}
+        else:
+            entry["reviewed"] = reviewed
+        manifest[filename] = entry
+        _save_manifest(manifest)
+
+
+def new_files_detected() -> List[Dict[str, Any]]:
+    """Detect new image files and return their metadata for review."""
+    pending: List[Dict[str, Any]] = []
+    with manifest_lock:
+        manifest = _load_manifest()
+        try:
+            disk_listing = os.listdir(IMAGES_DIR)
+        except OSError as exc:
+            logger.error("Unable to scan images directory %s: %s", IMAGES_DIR, exc)
+            disk_listing = []
+
+        # Drop manifest entries for files that no longer exist.
+        existing_files = {
+            name
+            for name in disk_listing
+            if (IMAGES_DIR / name).is_file() and _allowed_image(name)
+        }
+        to_remove = set(manifest.keys()) - existing_files
+        for orphan in to_remove:
+            manifest.pop(orphan, None)
+
+        # Ensure every file is tracked and has a sidecar file.
+        for filename in existing_files:
+            entry = manifest.get(filename)
+            if entry is None:
+                entry = {"reviewed": False, "detected_at": time.time()}
+                manifest[filename] = entry
+            image_path = IMAGES_DIR / filename
+            metadata = _load_metadata(image_path)
+            _ensure_sidecar(image_path, metadata)
+
+        _save_manifest(manifest)
+
+        for filename, entry in manifest.items():
+            if entry.get("reviewed"):
+                continue
+            image_path = IMAGES_DIR / filename
+            if not image_path.exists():
+                continue
+            metadata = _load_metadata(image_path)
+            pending.append(
+                {
+                    "name": filename,
+                    "url": f"/static/images/{filename}",
+                    "metadata": metadata,
+                    "detected_at": entry.get("detected_at"),
+                    "sidecar_exists": image_path.with_suffix(".json").exists(),
+                }
+            )
+
+    logger.debug("Pending review files: %s", [item["name"] for item in pending])
+    return pending
+
+
+async def _watch_image_directory(app: FastAPI) -> None:
+    """Background task that polls for new files."""
+    try:
+        while True:
+            pending = new_files_detected()
+            app.state.pending_images = pending
+            await asyncio.sleep(POLL_INTERVAL_SECONDS)
+    except asyncio.CancelledError:  # pragma: no cover - clean shutdown
+        logger.debug("Image directory watcher cancelled")
+        raise
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    app.state.pending_images = new_files_detected()
+    app.state.watcher_task = asyncio.create_task(_watch_image_directory(app))
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    watcher = getattr(app.state, "watcher_task", None)
+    if watcher:
+        watcher.cancel()
+        with suppress(asyncio.CancelledError):
+            await watcher
+
+def _load_metadata(image_path: Path) -> dict:
+    """Load metadata for an image.
+
+    Preference order:
+    1. JSON sidecar with same stem as image.
+    2. Embedded EXIF tags (ImageDescription, XPTitle, XPComment).
+    """
+    data: dict = {}
+    json_path = image_path.with_suffix(".json")
+    if json_path.exists():
+        try:
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            logger.warning(f"Invalid JSON in {json_path}: {e}")
+    else:
+        try:
+            with Image.open(image_path) as img:
+                exif = img.getexif()
+                if exif:
+                    for tag_id, value in exif.items():
+                        tag = ExifTags.TAGS.get(tag_id, tag_id)
+                        if tag == "ImageDescription" and value:
+                            data["description"] = value
+                        if tag == "XPTitle" and value:
+                            if isinstance(value, bytes):
+                                data["title"] = value.decode("utf-16-le").rstrip("\x00")
+                            else:
+                                data["title"] = value
+                        if tag == "XPComment" and value and "description" not in data:
+                            if isinstance(value, bytes):
+                                data["description"] = value.decode("utf-16-le").rstrip("\x00")
+                            else:
+                                data["description"] = value
+        except Exception as e:
+            logger.debug(f"Unable to extract EXIF from {image_path}: {e}")
+    data.setdefault("title", image_path.stem)
+    data.setdefault("description", "")
+    return data
+
+
 # --- Helper Function ---
 def get_artwork_files():
-    """
-    Scans the IMAGES_DIR and returns a list of dictionaries,
-    each containing the URL and name of an image file.
-    """
+    """Scan IMAGES_DIR and return metadata for each image."""
     artwork = []
-    # Define allowed image file extensions (case-insensitive)
-    allowed_extensions = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".bmp", ".tiff"}
     logger.info(f"Scanning for artwork in: {IMAGES_DIR}")
     if IMAGES_DIR.exists() and IMAGES_DIR.is_dir():
         try:
-            # Iterate through all files in the images directory
             for filename in os.listdir(IMAGES_DIR):
-                # Check if the file has an allowed image extension
                 file_path = IMAGES_DIR / filename
-                # Ensure it's a file, not a directory
-                if file_path.is_file():
-                    file_ext = os.path.splitext(filename)[1].lower()
-                    if file_ext in allowed_extensions:
-                        # Construct the web-accessible URL path for the image
-                        # This path corresponds to the StaticFiles mount point
-                        image_url = f"/static/images/{filename}"
-                        artwork.append({"url": image_url, "name": filename})
-                        logger.debug(f"Found artwork: {filename}")
-                    else:
-                        logger.debug(f"Skipping non-image file: {filename}")
+                if file_path.is_file() and _allowed_image(filename):
+                    meta = _load_metadata(file_path)
+                    image_url = f"/static/images/{filename}"
+                    meta.update({"url": image_url, "name": filename})
+                    artwork.append(meta)
+                    logger.debug(f"Loaded metadata for {filename}")
         except OSError as e:
             logger.error(f"Error reading image directory {IMAGES_DIR}: {e}")
-            return [] # Return empty list on error
+            return []
     else:
         logger.warning(f"Images directory not found or is not a directory: {IMAGES_DIR}")
 
@@ -77,6 +282,178 @@ def get_artwork_files():
     return artwork
 
 # --- Routes ---
+
+
+@app.get("/admin", response_class=HTMLResponse)
+async def admin_home(request: Request) -> HTMLResponse:
+    """Render the admin review dashboard."""
+    pending = new_files_detected()
+    request.app.state.pending_images = pending
+    return templates.TemplateResponse(
+        "reviewAddedFiles.html",
+        {
+            "request": request,
+            "pending_images": pending,
+            "allowed_extensions": sorted(ALLOWED_IMAGE_EXTENSIONS),
+        },
+    )
+
+
+@app.get("/admin/review", response_class=HTMLResponse)
+async def review_added_files(request: Request) -> HTMLResponse:
+    pending = new_files_detected()
+    request.app.state.pending_images = pending
+    return templates.TemplateResponse(
+        "reviewAddedFiles.html",
+        {
+            "request": request,
+            "pending_images": pending,
+            "allowed_extensions": sorted(ALLOWED_IMAGE_EXTENSIONS),
+        },
+    )
+
+
+@app.get("/admin/api/new-files", response_class=JSONResponse)
+async def api_new_files(request: Request) -> JSONResponse:
+    pending = new_files_detected()
+    request.app.state.pending_images = pending
+    return JSONResponse({"pending": pending})
+
+
+@app.post("/admin/upload")
+async def upload_images(
+    request: Request,
+    files: List[UploadFile] = File(...),
+) -> JSONResponse:
+    if not files:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No files uploaded")
+
+    saved: List[str] = []
+    skipped: List[str] = []
+
+    for upload in files:
+        filename = _sanitize_filename(upload.filename)
+        if not filename:
+            continue
+        suffix = Path(filename).suffix.lower()
+        if not _allowed_image(filename) and suffix != ".json":
+            skipped.append(filename)
+            continue
+
+        destination = IMAGES_DIR / filename
+        try:
+            with destination.open("wb") as buffer:
+                shutil.copyfileobj(upload.file, buffer)
+            saved.append(filename)
+        except OSError as exc:
+            logger.error("Failed to save %s: %s", filename, exc)
+            skipped.append(filename)
+        finally:
+            upload.file.close()
+
+    pending = new_files_detected()
+    request.app.state.pending_images = pending
+    message = "Uploaded files successfully" if saved else "No supported files uploaded"
+    return JSONResponse({"saved": saved, "skipped": skipped, "message": message, "pending": pending})
+
+
+@app.post("/admin/import-path")
+async def import_from_path(request: Request, path: str = Form(...)) -> JSONResponse:
+    source_path = Path(path).expanduser()
+    if not source_path.exists():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Path does not exist")
+
+    copied: List[str] = []
+    skipped: List[str] = []
+
+    def _handle_file(file_path: Path) -> None:
+        target_name = _sanitize_filename(file_path.name)
+        if _allowed_image(target_name) or file_path.suffix.lower() == ".json":
+            target = IMAGES_DIR / target_name
+            try:
+                shutil.copy2(file_path, target)
+                copied.append(target_name)
+            except OSError as exc:
+                logger.error("Failed to copy %s: %s", file_path, exc)
+                skipped.append(target_name)
+        else:
+            skipped.append(target_name)
+
+    if source_path.is_file():
+        _handle_file(source_path)
+    else:
+        for file_path in source_path.rglob("*"):
+            if file_path.is_file():
+                _handle_file(file_path)
+
+    pending = new_files_detected()
+    request.app.state.pending_images = pending
+    return JSONResponse({"copied": copied, "skipped": skipped, "pending": pending})
+
+
+@app.get("/admin/review/{image_name}", response_class=HTMLResponse)
+async def preview_image_metadata(request: Request, image_name: str) -> HTMLResponse:
+    filename = _sanitize_filename(image_name)
+    if not filename or not _allowed_image(filename):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    image_path = IMAGES_DIR / filename
+    if not image_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    metadata = _load_metadata(image_path)
+    _ensure_sidecar(image_path, metadata)
+
+    return templates.TemplateResponse(
+        "previewImageText.html",
+        {
+            "request": request,
+            "image_name": filename,
+            "image_url": f"/static/images/{filename}",
+            "metadata": metadata,
+            "review_url": request.url_for("review_added_files"),
+        },
+    )
+
+
+@app.post("/admin/metadata/{image_name}")
+async def update_image_metadata(
+    request: Request,
+    image_name: str,
+    title: str = Form(""),
+    description: str = Form(""),
+    action: str = Form("save"),
+) -> RedirectResponse:
+    filename = _sanitize_filename(image_name)
+    if not filename or not _allowed_image(filename):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    if action == "cancel":
+        return RedirectResponse(
+            url=request.url_for("review_added_files"),
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    image_path = IMAGES_DIR / filename
+    if not image_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    clean_metadata = {
+        "title": title.strip() or image_path.stem,
+        "description": description.strip(),
+    }
+    _write_sidecar(image_path, clean_metadata)
+    _set_review_status(filename, True)
+
+    pending = new_files_detected()
+    request.app.state.pending_images = pending
+
+    return RedirectResponse(
+        url=request.url_for("review_added_files"),
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
 @app.get("/", response_class=HTMLResponse)
 async def read_root(request: Request):
     """
@@ -99,10 +476,10 @@ async def read_root(request: Request):
 # --- Running the App ---
 # To run this app:
 # 1. Save this code as 'main.py'.
-# 2. Make sure you have the 'static/images' and 'templates' directories set up.
-# 3. Put artwork images in 'static/images'.
+# 2. Make sure you have the 'Static/images' and 'templates' directories set up.
+# 3. Put artwork images in 'Static/images'.
 # 4. Create 'templates/index.html' (code provided separately).
-# 5. Create `static/css/styles.css` (code provided separately).
+# 5. Create `Static/css/styles.css` (code provided separately).
 # 6. Create a virtual environment: python -m venv .venv
 # 7. Activate it: source .venv/bin/activate (or .\venv\Scripts\activate on Windows)
 # 8. Install necessary libraries: pip install "fastapi[all]"

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ gallery_title }}</title>
-    <link rel="stylesheet" href="{{ url_for('static', path='/css/styles.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎨</text></svg>">
 </head>
 <body>
@@ -18,19 +18,22 @@
             <div class="gallery-grid">
                 {% for artwork in artwork_files %}
                     <div class="artwork-item">
-                        <a href="{{ artwork.url }}" target="_blank" title="View full size: {{ artwork.name }}">
+                        <a href="{{ artwork.url }}" target="_blank" title="View full size: {{ artwork.title }}">
                             <img src="{{ artwork.url }}"
-                                 alt="{{ artwork.name }}"
+                                 alt="{{ artwork.title }}"
                                  loading="lazy"
                                  onerror="this.onerror=null; this.src='https://placehold.co/250x200/EEE/CCC?text=Image+Not+Found'; this.alt='Image not found';">
                         </a>
-                        <p class="artwork-name">{{ artwork.name }}</p>
+                        <p class="artwork-title">{{ artwork.title }}</p>
+                        {% if artwork.description %}
+                        <p class="artwork-description">{{ artwork.description }}</p>
+                        {% endif %}
                     </div>
                 {% endfor %}
             </div>
         {% else %}
             <p class="no-artwork-message">
-                No artwork images found in the 'static/images' folder.
+                No artwork images found in the 'Static/images' folder.
                 <br>
                 Please add some images (e.g., .jpg, .png, .gif) to that folder.
             </p>

--- a/templates/previewImageText.html
+++ b/templates/previewImageText.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Review {{ metadata.title }} &mdash; Artwork Admin</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
+</head>
+<body class="admin-page">
+    <header>
+        <h1>Review metadata</h1>
+        <nav class="admin-nav">
+            <a href="{{ review_url }}" class="button secondary">Back to pending list</a>
+            <a href="/" class="button secondary">View Public Gallery</a>
+        </nav>
+    </header>
+
+    <main class="admin-container single">
+        <section class="admin-panel">
+            <h2>{{ metadata.title }}</h2>
+            <div class="preview-wrapper">
+                <img src="{{ image_url }}" alt="Preview of {{ metadata.title }}" class="preview-image">
+                <dl class="preview-meta">
+                    <div>
+                        <dt>Filename</dt>
+                        <dd>{{ image_name }}</dd>
+                    </div>
+                    <div>
+                        <dt>Image URL</dt>
+                        <dd><a href="{{ image_url }}" target="_blank" rel="noopener">{{ image_url }}</a></dd>
+                    </div>
+                </dl>
+            </div>
+        </section>
+
+        <section class="admin-panel">
+            <h2>Edit text for this image</h2>
+            <p class="panel-description">Update the fields below to control the title and description that accompany the artwork in the public gallery. Saving will also update or create the JSON sidecar file.</p>
+            <form class="metadata-form" method="post" action="{{ url_for('update_image_metadata', image_name=image_name) }}">
+                <div class="form-field">
+                    <label for="title">Title</label>
+                    <input type="text" id="title" name="title" value="{{ metadata.title | e }}" required>
+                </div>
+                <div class="form-field">
+                    <label for="description">Description</label>
+                    <textarea id="description" name="description" rows="6" placeholder="Describe the story, medium, or inspiration for this piece.">{{ metadata.description | e }}</textarea>
+                </div>
+                <div class="form-actions">
+                    <button type="submit" name="action" value="save" class="button">OK</button>
+                    <button type="submit" name="action" value="cancel" class="button secondary">Cancel</button>
+                </div>
+            </form>
+        </section>
+    </main>
+
+    <footer>
+        <p>Artwork Gallery Administration</p>
+    </footer>
+</body>
+</html>

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Artwork Admin Review</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
+</head>
+<body class="admin-page">
+    <header>
+        <h1>Artwork Administration</h1>
+        <p class="admin-subheading">Upload, detect, and describe the images that appear in your gallery.</p>
+        <nav class="admin-nav">
+            <a href="/" class="button secondary">View Public Gallery</a>
+            <button type="button" id="refresh-pending" class="button secondary">Refresh Pending List</button>
+        </nav>
+    </header>
+
+    <main class="admin-container">
+        <section class="admin-panel">
+            <h2>Upload new artwork</h2>
+            <p class="panel-description">Drag and drop image files or click below to open a file browser. You can also include existing JSON sidecar files.</p>
+            <div id="dropzone" class="dropzone" role="button" tabindex="0" aria-label="Drop images here or press enter to choose files">
+                <svg aria-hidden="true" focusable="false" class="dropzone-icon" viewBox="0 0 24 24">
+                    <path d="M12 2a5 5 0 0 1 5 5h3a1 1 0 1 1 0 2h-3v2h1a4 4 0 1 1 0 8H7a5 5 0 0 1-1-9.9V9H3a1 1 0 1 1 0-2h3a5 5 0 0 1 6-5Zm0 2a3 3 0 0 0-3 3v2a1 1 0 0 1-1 1H7a3 3 0 1 0 0 6h11a2 2 0 1 0 0-4h-2a1 1 0 0 1-1-1V7a3 3 0 0 0-3-3Zm0 4a1 1 0 0 1 1 1v2.585l1.293-1.293a1 1 0 1 1 1.414 1.414l-3.004 3.003a1 1 0 0 1-1.414 0l-3.004-3.003a1 1 0 0 1 1.414-1.414L11 11.585V9a1 1 0 0 1 1-1Z" fill="currentColor"/>
+                </svg>
+                <p><strong>Drop files here</strong> or use the button below.</p>
+                <button type="button" id="select-files" class="button">Choose files</button>
+                <input type="file" id="file-input" name="files" accept="image/*,.json" multiple hidden>
+                <p class="supported-formats">Supported formats: {{ allowed_extensions | join(', ') }} and JSON sidecars.</p>
+            </div>
+
+            <form id="path-form" class="path-form">
+                <h3>Import from server path</h3>
+                <p class="panel-description">Paste an absolute file or directory path that the server can read. Images will be copied into <code>Static/images</code>.</p>
+                <label for="path-input" class="sr-only">Absolute path on the server</label>
+                <div class="path-input-row">
+                    <input type="text" id="path-input" name="path" placeholder="/home/user/photos" required>
+                    <button type="submit" class="button">Import</button>
+                </div>
+            </form>
+        </section>
+
+        <section class="admin-panel">
+            <div class="panel-header">
+                <h2>Pending review <span id="pending-count" class="badge">{{ pending_images | length }}</span></h2>
+                <p class="panel-description">Review each image to confirm or edit the metadata that appears to visitors.</p>
+            </div>
+            <div id="pending-list" class="pending-list" aria-live="polite">
+                {% if pending_images %}
+                    {% for item in pending_images %}
+                        <article class="pending-card" data-image-name="{{ item.name }}">
+                            <div class="pending-thumb">
+                                <img src="{{ item.url }}" alt="Preview of {{ item.metadata.title }}" loading="lazy">
+                            </div>
+                            <div class="pending-info">
+                                <h3>{{ item.metadata.title }}</h3>
+                                <p class="filename">{{ item.name }}</p>
+                                {% if item.metadata.description %}
+                                    <p class="description">{{ item.metadata.description }}</p>
+                                {% else %}
+                                    <p class="description empty">No description detected yet.</p>
+                                {% endif %}
+                                <a class="button" href="{{ url_for('preview_image_metadata', image_name=item.name) }}">Review details</a>
+                            </div>
+                        </article>
+                    {% endfor %}
+                {% else %}
+                    <p class="empty-state">No new files waiting for review. Upload artwork to begin curating descriptions.</p>
+                {% endif %}
+            </div>
+        </section>
+    </main>
+
+    <section id="feedback" class="feedback" role="status" aria-live="polite" hidden></section>
+
+    <footer>
+        <p>Artwork Gallery Administration</p>
+    </footer>
+
+    <script>
+    const dropzone = document.getElementById('dropzone');
+    const fileInput = document.getElementById('file-input');
+    const selectFilesButton = document.getElementById('select-files');
+    const feedback = document.getElementById('feedback');
+    const pendingList = document.getElementById('pending-list');
+    const pendingCount = document.getElementById('pending-count');
+    const refreshButton = document.getElementById('refresh-pending');
+    const pathForm = document.getElementById('path-form');
+
+    function showFeedback(message, type = 'info') {
+        feedback.textContent = message;
+        feedback.classList.remove('error', 'success');
+        feedback.classList.add(type === 'error' ? 'error' : 'success');
+        feedback.hidden = false;
+        window.setTimeout(() => {
+            feedback.hidden = true;
+        }, 8000);
+    }
+
+    function renderPendingList(pending) {
+        pendingList.innerHTML = '';
+        if (!pending || pending.length === 0) {
+            const emptyMessage = document.createElement('p');
+            emptyMessage.className = 'empty-state';
+            emptyMessage.textContent = 'No new files waiting for review. Upload artwork to begin curating descriptions.';
+            pendingList.appendChild(emptyMessage);
+        } else {
+            pending.forEach((item) => {
+                const card = document.createElement('article');
+                card.className = 'pending-card';
+                card.dataset.imageName = item.name;
+
+                const thumb = document.createElement('div');
+                thumb.className = 'pending-thumb';
+                const img = document.createElement('img');
+                img.src = item.url;
+                img.alt = `Preview of ${item.metadata?.title || item.name}`;
+                img.loading = 'lazy';
+                thumb.appendChild(img);
+                card.appendChild(thumb);
+
+                const info = document.createElement('div');
+                info.className = 'pending-info';
+
+                const title = document.createElement('h3');
+                title.textContent = item.metadata?.title || item.name;
+                info.appendChild(title);
+
+                const filename = document.createElement('p');
+                filename.className = 'filename';
+                filename.textContent = item.name;
+                info.appendChild(filename);
+
+                const description = document.createElement('p');
+                description.className = 'description';
+                const desc = item.metadata?.description;
+                if (desc) {
+                    description.textContent = desc;
+                } else {
+                    description.classList.add('empty');
+                    description.textContent = 'No description detected yet.';
+                }
+                info.appendChild(description);
+
+                const link = document.createElement('a');
+                link.className = 'button';
+                link.href = `/admin/review/${encodeURIComponent(item.name)}`;
+                link.textContent = 'Review details';
+                info.appendChild(link);
+
+                card.appendChild(info);
+                pendingList.appendChild(card);
+            });
+        }
+        if (pendingCount) {
+            pendingCount.textContent = pending ? pending.length : 0;
+        }
+    }
+
+    async function uploadFiles(files) {
+        if (!files || files.length === 0) {
+            return;
+        }
+        const formData = new FormData();
+        Array.from(files).forEach((file) => formData.append('files', file));
+
+        const response = await fetch('/admin/upload', {
+            method: 'POST',
+            body: formData,
+        });
+        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(data.detail || 'Upload failed');
+        }
+        renderPendingList(data.pending || []);
+        const saved = data.saved?.length ? `Saved: ${data.saved.join(', ')}` : '';
+        const skipped = data.skipped?.length ? ` Skipped: ${data.skipped.join(', ')}` : '';
+        showFeedback(`${data.message || 'Upload complete.'} ${saved}${skipped}`.trim(), 'success');
+    }
+
+    async function fetchPending(showMessage = false) {
+        const response = await fetch('/admin/api/new-files');
+        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(data.detail || 'Unable to refresh pending files');
+        }
+        renderPendingList(data.pending || []);
+        if (showMessage) {
+            showFeedback('Pending list refreshed.', 'success');
+        }
+    }
+
+    if (dropzone) {
+        ['dragenter', 'dragover'].forEach((eventName) => {
+            dropzone.addEventListener(eventName, (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                dropzone.classList.add('is-dragover');
+            });
+        });
+
+        ['dragleave', 'dragend', 'drop'].forEach((eventName) => {
+            dropzone.addEventListener(eventName, (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                dropzone.classList.remove('is-dragover');
+            });
+        });
+
+        dropzone.addEventListener('drop', async (event) => {
+            try {
+                await uploadFiles(event.dataTransfer.files);
+            } catch (error) {
+                console.error(error);
+                showFeedback(error.message, 'error');
+            }
+        });
+
+        dropzone.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                fileInput?.click();
+            }
+        });
+    }
+
+    selectFilesButton?.addEventListener('click', () => fileInput?.click());
+
+    fileInput?.addEventListener('change', async (event) => {
+        try {
+            await uploadFiles(event.target.files);
+            event.target.value = '';
+        } catch (error) {
+            console.error(error);
+            showFeedback(error.message, 'error');
+        }
+    });
+
+    pathForm?.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(pathForm);
+        try {
+            const response = await fetch('/admin/import-path', {
+                method: 'POST',
+                body: formData,
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.detail || 'Import failed');
+            }
+            renderPendingList(data.pending || []);
+            const copied = data.copied?.length ? `Imported: ${data.copied.join(', ')}` : '';
+            const skipped = data.skipped?.length ? ` Skipped: ${data.skipped.join(', ')}` : '';
+            showFeedback(`${copied}${skipped}`.trim() || 'Import complete.', 'success');
+            pathForm.reset();
+        } catch (error) {
+            console.error(error);
+            showFeedback(error.message, 'error');
+        }
+    });
+
+    refreshButton?.addEventListener('click', async () => {
+        try {
+            await fetchPending(true);
+        } catch (error) {
+            console.error(error);
+            showFeedback(error.message, 'error');
+        }
+    });
+
+    window.setInterval(async () => {
+        try {
+            await fetchPending(false);
+        } catch (error) {
+            console.error(error);
+        }
+    }, 15000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add manifest tracking, background polling, and admin API endpoints for uploading artwork and flagging new files for review
- create admin templates to list pending images, edit metadata, and ensure JSON sidecars are created when missing
- extend shared styles and documentation to cover the administrative workflow

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c64c9ff36883269afae817e520987e