### PR TITLE
Add OpenAI-powered metadata generation for new images

### DIFF
--- a/ImageSidecar.schema.json
+++ b/ImageSidecar.schema.json
@@ -13,6 +13,58 @@
       "type": "string",
       "default": ""
     },
+    "ai_generated": {
+      "type": "boolean",
+      "description": "Indicates whether AI generated the current title or description.",
+      "default": false
+    },
+    "ai_details": {
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "default": ""
+        },
+        "model": {
+          "type": "string",
+          "default": ""
+        },
+        "prompt": {
+          "type": "string",
+          "default": ""
+        },
+        "response_id": {
+          "type": "string",
+          "default": ""
+        },
+        "finish_reason": {
+          "type": "string",
+          "default": ""
+        },
+        "created": {
+          "type": "number",
+          "default": 0
+        },
+        "attempted_at": {
+          "type": "number",
+          "default": 0
+        },
+        "status": {
+          "type": "string",
+          "default": ""
+        },
+        "error": {
+          "type": "string",
+          "default": ""
+        },
+        "raw_response": {
+          "type": "object",
+          "default": {}
+        }
+      }
+    },
     "reviewed": {
       "type": "boolean",
       "default": false
@@ -23,6 +75,13 @@
       "default": 0
     }
   },
-  "required": ["title", "description", "reviewed", "detected_at"]
+  "required": [
+    "title",
+    "description",
+    "ai_generated",
+    "ai_details",
+    "reviewed",
+    "detected_at"
+  ]
 }
 


### PR DESCRIPTION
## Summary
- add OpenAI vision integration that inspects EXIF titles, generates missing metadata, and records AI response details
- extend the image sidecar schema and management script to persist AI provenance fields alongside human edits

## Testing
- python -m compileall main.py manage_sidecars.py

------
https://chatgpt.com/codex/tasks/task_e_68d24e61b7ac8326b96fe02f2c950e58