### PR TITLE
Refine artwork detail page styling

### DIFF
--- a/Static/css/style-nasturtium-lagoon 2.css
+++ b/Static/css/style-nasturtium-lagoon 2.css
@@ -79,6 +79,53 @@ header h1 {
     letter-spacing: .02em
 }
 
+.gallery-subtitle {
+    max-width: 720px;
+    margin: .35rem auto 0;
+    color: color-mix(in oklab, var(--text) 70%, var(--muted) 30%);
+    font-size: 1rem;
+}
+
+.hero-panel {
+    max-width: 960px;
+    margin: 1.25rem auto 0;
+    padding: 1.5rem 1.25rem;
+    border-radius: var(--radius);
+    border: 1px solid var(--muted);
+    background: color-mix(in oklab, var(--bg) 90%, var(--muted-2) 10%);
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 1rem;
+}
+
+.hero-tagline {
+    font-size: 1.2rem;
+    margin: 0 0 .35rem;
+    color: color-mix(in oklab, var(--text) 85%, var(--sea) 15%);
+}
+
+.hero-description {
+    margin: 0;
+    color: color-mix(in oklab, var(--text) 70%, var(--muted) 30%);
+}
+
+.hero-hints {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+}
+
+.hero-hints span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: .35rem .8rem;
+    border-radius: 999px;
+    border: 1px solid var(--muted);
+    color: color-mix(in oklab, var(--text) 70%, var(--muted) 30%);
+    font-size: .85rem;
+}
+
 /* Main */
 main {
     padding: 2rem 1rem;
@@ -95,6 +142,159 @@ main {
     grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
     gap: 1.6rem 1.4rem;
     justify-content: center
+}
+
+/* Detail page */
+.detail-page header {
+    padding-bottom: 0;
+}
+
+.detail-header h1 {
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    letter-spacing: .04em;
+}
+
+.detail-subtitle {
+    max-width: 780px;
+    margin: .75rem auto 0;
+    font-size: 1rem;
+    color: color-mix(in oklab, var(--text) 70%, var(--muted) 30%);
+}
+
+.detail-nav-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .35rem;
+    margin-bottom: 1rem;
+    padding: .45rem .9rem;
+    border-radius: 999px;
+    border: 1px solid var(--muted);
+    color: color-mix(in oklab, var(--text) 80%, var(--sea) 20%);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.detail-nav-link:hover,
+.detail-nav-link:focus {
+    background-color: color-mix(in oklab, var(--bg) 86%, var(--sea) 14%);
+}
+
+.detail-hero {
+    margin-top: 1.5rem;
+}
+
+.detail-hints span {
+    border-color: color-mix(in oklab, var(--muted) 60%, var(--sea) 40%);
+    background-color: color-mix(in oklab, var(--bg) 92%, var(--sea) 8%);
+    color: color-mix(in oklab, var(--text) 70%, var(--sea) 30%);
+}
+
+.artwork-detail-main {
+    padding: 2.5rem 1rem 3rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.artwork-detail-layout {
+    display: grid;
+    gap: 2.5rem;
+    width: 100%;
+}
+
+.detail-image-panel {
+    background: linear-gradient(180deg, color-mix(in oklab, var(--bg) 85%, var(--sea) 15%), var(--bg));
+    padding: 1rem;
+    border-radius: 18px;
+    border: 1px solid color-mix(in oklab, var(--muted) 70%, var(--sea) 30%);
+    box-shadow: var(--shadow);
+}
+
+.detail-image-link {
+    display: block;
+    border-radius: 12px;
+    overflow: hidden;
+    background-color: color-mix(in oklab, var(--bg) 80%, var(--muted-2) 20%);
+}
+
+.detail-image-panel img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    border-radius: 12px;
+    max-height: 75vh;
+    border: 1px solid color-mix(in oklab, var(--muted) 65%, var(--sand) 35%);
+}
+
+.detail-caption {
+    margin-top: .75rem;
+    font-size: .9rem;
+    color: color-mix(in oklab, var(--text) 60%, var(--muted) 40%);
+    text-align: center;
+}
+
+.detail-info-panel {
+    background-color: var(--surface);
+    border: 1px solid var(--muted);
+    border-radius: 18px;
+    padding: 2rem;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.detail-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+}
+
+.detail-meta span {
+    border-radius: 999px;
+    padding: .35rem .9rem;
+    background-color: color-mix(in oklab, var(--bg) 92%, var(--sea) 8%);
+    border: 1px solid color-mix(in oklab, var(--muted) 50%, var(--sea) 50%);
+    font-size: .8rem;
+    color: color-mix(in oklab, var(--text) 70%, var(--sea) 30%);
+    letter-spacing: .03em;
+}
+
+.detail-description {
+    font-size: 1.05rem;
+    color: color-mix(in oklab, var(--text) 85%, var(--muted) 15%);
+    line-height: 1.75;
+}
+
+.detail-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+}
+
+.detail-actions .button,
+.detail-actions .button.secondary {
+    flex: 1 1 220px;
+}
+
+@media (min-width: 860px) {
+    .artwork-detail-layout {
+        grid-template-columns:minmax(420px, 1.2fr) minmax(320px, 1fr);
+        align-items: stretch;
+    }
+}
+
+@media (max-width: 640px) {
+    .detail-info-panel {
+        padding: 1.5rem;
+    }
+
+    .detail-actions {
+        flex-direction: column;
+    }
 }
 
 /* Card */

--- a/templates/artwork_detail.html
+++ b/templates/artwork_detail.html
@@ -4,27 +4,61 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ artwork.title }}</title>
-    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/style-nasturtium-lagoon 2.css') }}">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎨</text></svg>">
 </head>
-<body class="artwork-page">
+<body class="gallery-page detail-page">
     <div class="page-container">
-        <section class="artwork-highlight" aria-labelledby="artwork-title">
-            <figure class="artwork-frame">
-                <a href="{{ artwork.image_url }}" target="_blank" rel="noopener" title="Open full-resolution image in a new tab">
-                    <img src="{{ artwork.image_url }}" alt="{{ artwork.title }}">
-                </a>
-            </figure>
-            <article class="artwork-card">
-                <div class="artwork-meta">
-                    <span>Featured highlight</span>
-                    <span>Immersive texture study</span>
-                    <span>Color-forward composition</span>
+        <header class="gallery-header detail-header">
+            <a href="/" class="detail-nav-link" aria-label="Return to gallery overview">⟵ Back to Gallery</a>
+            <h1 id="artwork-title">{{ artwork.title }}</h1>
+            <p class="gallery-subtitle detail-subtitle">
+                {{ artwork.description or 'A closer look at the tones, gestures, and luminous textures that shape this piece.' }}
+            </p>
+            <section class="hero-panel detail-hero" aria-label="Artwork introduction">
+                <div>
+                    <p class="hero-tagline">Full-frame focus</p>
+                    <p class="hero-description">
+                        Let the palette breathe in a dedicated space that mirrors the gallery mood—soft gradients, gentle glow, and
+                        clear typography to spotlight the narrative of this single work.
+                    </p>
                 </div>
-                <h1 id="artwork-title" class="artwork-title">{{ artwork.title }}</h1>
-                <p class="artwork-description">{{ artwork.description or 'This piece invites you to explore the nuances of the artist’s palette—follow the gradients, the soft light, and the hidden gestures that reveal themselves slowly.' }}</p>
-                <a href="/" class="back-link" aria-label="Return to gallery">⟵ Back to Gallery</a>
-            </article>
-        </section>
+                <div class="hero-hints detail-hints">
+                    <span title="Curated specifically from the gallery grid">✨ Gallery spotlight</span>
+                    <span title="Tap the image to open it in a new tab">🖼 Full-resolution view</span>
+                    <span title="Typography scales to keep long-form notes legible">📝 Readable story text</span>
+                </div>
+            </section>
+        </header>
+
+        <main class="artwork-detail-main">
+            <section class="artwork-detail-layout" aria-labelledby="artwork-title">
+                <figure class="detail-image-panel">
+                    <a href="{{ artwork.image_url }}" target="_blank" rel="noopener" class="detail-image-link" title="Open full-resolution image in a new tab">
+                        <img src="{{ artwork.image_url }}" alt="{{ artwork.title }}">
+                    </a>
+                    <figcaption class="detail-caption">Tap or click to open the original size in a separate tab.</figcaption>
+                </figure>
+                <article class="detail-info-panel">
+                    <div class="detail-meta">
+                        <span>Featured highlight</span>
+                        <span>Immersive texture study</span>
+                        <span>Color-forward composition</span>
+                    </div>
+                    <p class="detail-description">
+                        {{ artwork.description or 'This piece invites you to explore the nuances of the artist’s palette—follow the gradients, the soft light, and the hidden gestures that reveal themselves slowly.' }}
+                    </p>
+                    <div class="detail-actions">
+                        <a href="{{ artwork.image_url }}" target="_blank" rel="noopener" class="button">Open full resolution</a>
+                        <a href="/" class="button secondary">Back to gallery</a>
+                    </div>
+                </article>
+            </section>
+        </main>
+
+        <footer>
+            <p>Artwork Gallery · Crafted for the curious eye</p>
+        </footer>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `artwork_detail.html` to reuse the same hero framing, typography, and footer structure as the gallery along with better copy and actions
- extend the Nasturtium Lagoon stylesheet with hero, subtitle, and detail-page specific rules so the detailed view mirrors the gallery aesthetic and scales responsively

## Testing
- uvicorn main:app --host 0.0.0.0 --port 8000


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6919533b1ad88331887e59dd2ac364f2)