### PR TITLE
Add branching strategy and fix CLAUDE.md PR workflow

### DIFF
--- a/BRANCHING_STRATEGY.md
+++ b/BRANCHING_STRATEGY.md
@@ -1,0 +1,144 @@
+# Branching Strategy
+
+## Branch Model
+
+```
+main (production)          ← deployed to Railway production environment
+  └── dev (integration)    ← default working branch, all feature branches start here
+       ├── feat/...        ← new features
+       ├── fix/...         ← bug fixes
+       ├── docs/...        ← documentation changes
+       └── chore/...       ← maintenance, deps, CI config
+```
+
+### Branch Roles
+
+| Branch | Purpose | Deploys To | Protected |
+|--------|---------|------------|-----------|
+| `main` | Production-ready code | Railway production | Yes — PR required, all threads resolved |
+| `dev` | Integration and staging | Railway staging (when configured) | Yes — PR required |
+| `feat/*`, `fix/*`, `docs/*`, `chore/*` | Short-lived work branches | Railway PR previews (when configured) | No |
+
+### Rules
+
+- **Always branch from `dev`**, never from `main`.
+- PRs from feature branches target `dev`. `dev` is promoted to `main` for production releases.
+- Direct pushes to `dev` and `main` are blocked by GitHub rulesets.
+- Force-push and branch deletion are blocked on `dev` and `main`.
+- Keep branches short-lived — merge or close within days, not weeks.
+
+## GitHub Rulesets
+
+Two rulesets enforce branch protection:
+
+### `dev` (targets default branch)
+
+- No direct push, no force-push, no deletion
+- Pull request required (0 approvals minimum)
+- Copilot code review on push and drafts
+- CodeQL security scanning (high+ security, errors threshold)
+- Code quality checks (errors threshold)
+
+### `main_railway_production` (targets `main`, `production`, `prod`)
+
+- Everything in the `dev` ruleset, plus:
+- **Required review thread resolution** — every PR comment thread must be resolved before merge
+- Allowed merge methods: rebase or merge commit (no squash)
+
+## PR Lifecycle
+
+1. **Branch** — `git checkout dev && git pull origin dev && git checkout -b feat/my-thing dev`
+2. **Develop** — make changes, commit with clear messages.
+3. **Push** — `git push -u origin feat/my-thing`
+4. **Open PR** — target `dev`. Open as draft if still in progress; ready for review if mergeable. Write a summary and test plan.
+5. **Automated checks** — wait for CodeQL, Copilot review, and code quality to pass.
+6. **Review** — request review if needed. Read every comment carefully.
+7. **Respond** — reply to each review thread. Push fix commits (don't force-push).
+8. **Resolve threads** — all comment threads must be marked resolved (enforced by ruleset on `main`).
+9. **Merge** — use rebase or merge commit. Delete the feature branch after merge.
+
+### Check Branch Status
+
+```bash
+bash scripts/ahead-behind.sh              # all branches vs repo default
+bash scripts/ahead-behind.sh --base dev   # all branches vs dev
+bash scripts/ahead-behind.sh 5 --newest   # 5 most recently updated branches
+```
+
+## Railway Environments
+
+Railway supports multiple environments tied to branches. Each environment has its own service instances, variables, and (optionally) volumes.
+
+### Production (`main`)
+
+- **Branch**: `main`
+- **Auto-deploy**: on push/merge to `main`
+- **Volume**: persistent storage mounted at `/data/images` (`IMAGES_DIR=/data/images`)
+- **Variables**: `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `MY_OPENAI_API_KEY`, and other production secrets set in Railway dashboard
+- **Domain**: production URL configured in Railway
+
+### PR Deploy Previews (planned)
+
+Railway can spin up isolated environments for each pull request, giving reviewers a live preview before merging.
+
+**What PR previews provide:**
+- Temporary environment created automatically when a PR is opened
+- Own service instance with the PR's code deployed
+- Isolated variables (can inherit from production or use test values)
+- Unique preview URL for each PR
+- Auto-teardown when the PR is merged or closed
+
+**Setup steps (after initial PRs are merged):**
+1. Enable "PR Deploy Previews" in the Railway service settings
+2. Connect the GitHub repo if not already linked
+3. Configure environment variables for preview environments (use test API keys, separate admin credentials)
+4. Decide on volume strategy — previews can share a read-only volume snapshot or use ephemeral storage
+5. Set a base environment to inherit variables from
+
+**Considerations for this project:**
+- Preview environments will need their own `ADMIN_PASSWORD` (set a shared test password in Railway's PR environment config)
+- `IMAGES_DIR` can be left unset (defaults to `Static/images/` with bundled test images) or pointed at a preview volume
+- `MY_OPENAI_API_KEY` — use a separate key with lower rate limits for previews, or leave unset to disable AI features in previews
+- Preview URLs are temporary — don't use them for anything persistent
+
+### Environment Variable Matrix
+
+| Variable | Production | PR Preview |
+|----------|-----------|------------|
+| `IMAGES_DIR` | `/data/images` (volume) | unset (uses `Static/images/`) |
+| `ADMIN_USERNAME` | `admin` | `admin` |
+| `ADMIN_PASSWORD` | production secret | shared test password |
+| `MY_OPENAI_API_KEY` | production key | test key or unset |
+| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-4o-mini` | `gpt-4o-mini` |
+| `MAX_UPLOAD_SIZE_MB` | `50` | `50` |
+| `PORT` | set by Railway | set by Railway |
+
+## Workflow Summary
+
+```
+developer creates feat/thing from dev
+       │
+       ▼
+push to origin/feat/thing
+       │
+       ▼
+open PR targeting dev ──► Railway PR preview spins up (when enabled)
+       │
+       ▼
+automated checks run (CodeQL, Copilot, code quality)
+       │
+       ▼
+code review ◄──► fix and respond to comments
+       │
+       ▼
+all threads resolved, checks pass
+       │
+       ▼
+merge to dev ──► dev promoted to main for production release
+       │
+       ▼
+merge to main ──► Railway production auto-deploys
+       │
+       ▼
+delete feat/thing branch
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Static/                  # Mounted at /static (preserve capital S)
   css/                   # Stylesheets (Techno-Botanical design system)
   images/                # Artwork files + co-located .json sidecars
 artazzen-design-system/  # Design system spec and tokens
-data/orders.jsonl        # Order data
+scripts/ahead-behind.sh  # Branch divergence checker
 tests/test_main.py       # Pytest suite
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Artwork gallery and curation platform built with FastAPI + Jinja2. Public galler
 
 @AGENTS.md
 @DESIGN.md
+@BRANCHING_STRATEGY.md
 
 ## Quick Start
 
@@ -106,18 +107,17 @@ git checkout dev && git pull origin dev
 git checkout -b feature/my-thing dev
 ```
 
-Always branch from `dev`, never from `main`. PRs target `main`.
+Always branch from `dev`, never from `main`. PRs target `dev`.
+
+On completion of any `feat/`, `fix/`, `docs/`, or `chore/` branch: commit, push, and open a PR targeting `dev`. Open as **draft** if work is still in progress or needs discussion; open as **ready for review** if all checks should pass and it's mergeable.
 
 ### Branch Protection
 
-Direct pushes to `dev` and `main` are **blocked** by GitHub rulesets. All changes go through pull requests.
-
-- **`dev` ruleset** — requires PR, Copilot code review on push, CodeQL scanning, code quality checks. No force-push, no deletion.
-- **`main_railway_production` ruleset** — same as dev plus **required review thread resolution** (all PR comments must be resolved before merge). Targets `main`, `production`, and `prod`.
+Direct pushes to `dev` and `main` are **blocked** by GitHub rulesets. All changes go through pull requests. See `BRANCHING_STRATEGY.md` for full ruleset details.
 
 ### PR Lifecycle
 
-1. **Create a PR** from your feature branch targeting `main`.
+1. **Create a PR** from your feature branch targeting `dev`.
 2. **Wait for automated checks** — CodeQL, Copilot review, and code quality must pass.
 3. **Request review** if needed; respond to every comment.
 4. **Read all review comments** — do not merge with unread feedback.


### PR DESCRIPTION
## Summary
- Add `BRANCHING_STRATEGY.md` — branch model, GitHub rulesets, PR lifecycle, Railway environments, env var matrix
- Update `CLAUDE.md`: PRs target `dev` not `main`, agent auto-PR on branch completion, fix architecture tree (`data/` → `scripts/`)

Re-opened from #34 which was auto-closed when its stacked base branch was deleted.

## Test plan
- [ ] Verify BRANCHING_STRATEGY.md matches GitHub rulesets
- [ ] Confirm CLAUDE.md architecture tree only lists tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147Vq9oNTpzMzmNPEeySZd3
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

