### PR TITLE
Fix all CodeQL path-injection and exception-exposure findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ ADMIN_PASSWORD=
 # On Railway, set to the mounted volume path:
 # IMAGES_DIR=/data/images
 
+# Admin filesystem imports are restricted to this directory. Relative paths
+# submitted to /admin/import-path are resolved beneath it.
+# IMPORT_ROOT=/data/images/imports
+
 # OpenAI — for AI-powered metadata generation
 MY_OPENAI_API_KEY=
 OPENAI_IMAGE_METADATA_MODEL=gpt-4o-mini

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ __pycache__/
 app_repro.log
 claude-skills/
 data/
+/imports/
 final_test.log
 logs/
-

--- a/BRANCHING_STRATEGY.md
+++ b/BRANCHING_STRATEGY.md
@@ -98,6 +98,7 @@ Railway can spin up isolated environments for each pull request, giving reviewer
 **Considerations for this project:**
 - Preview environments will need their own `ADMIN_PASSWORD` (set a shared test password in Railway's PR environment config)
 - `IMAGES_DIR` can be left unset (defaults to `Static/images/` with bundled test images) or pointed at a preview volume
+- `IMPORT_ROOT` limits admin filesystem imports to one approved staging directory; keep the default ephemeral `imports/` directory or set an explicit preview path
 - `MY_OPENAI_API_KEY` — use a separate key with lower rate limits for previews, or leave unset to disable AI features in previews
 - Preview URLs are temporary — don't use them for anything persistent
 
@@ -106,6 +107,7 @@ Railway can spin up isolated environments for each pull request, giving reviewer
 | Variable | Production | PR Preview |
 |----------|-----------|------------|
 | `IMAGES_DIR` | `/data/images` (volume) | unset (uses `Static/images/`) |
+| `IMPORT_ROOT` | `/data/images/imports` or another approved staging directory | unset (uses `imports/`) |
 | `ADMIN_USERNAME` | `admin` | `admin` |
 | `ADMIN_PASSWORD` | production secret | shared test password |
 | `MY_OPENAI_API_KEY` | production key | test key or unset |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ See `.env.example` for the full list. Key vars:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `IMAGES_DIR` | `Static/images` | Image storage path. Set to `/data/images` on Railway |
+| `IMPORT_ROOT` | `imports` | Only server directory allowed as a source for admin filesystem imports |
 | `ADMIN_USERNAME` | `admin` | Basic auth username for admin |
 | `ADMIN_PASSWORD` | *(none)* | Basic auth password (**required** for admin) |
 | `MY_OPENAI_API_KEY` | *(none)* | OpenAI API key for AI metadata |

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ STATIC_DIR = BASE_DIR / "Static"
 IMAGES_DIR = Path(os.getenv("IMAGES_DIR", STATIC_DIR / "images"))
 _USING_VOLUME = IMAGES_DIR != STATIC_DIR / "images"
 IMAGES_URL_PREFIX = "/images" if _USING_VOLUME else "/static/images"
+IMPORT_ROOT = Path(os.getenv("IMPORT_ROOT", BASE_DIR / "imports"))
 TEMPLATES_DIR = BASE_DIR / "templates"
 SCHEMA_PATH = BASE_DIR / "ImageSidecar.schema.json"
 CONFIG_PATH = BASE_DIR / "ai_config.json"
@@ -85,6 +86,7 @@ except ValueError:
 # exist_ok=True prevents an error if the directory already exists
 STATIC_DIR.mkdir(parents=True, exist_ok=True)
 IMAGES_DIR.mkdir(parents=True, exist_ok=True)
+IMPORT_ROOT.mkdir(parents=True, exist_ok=True)
 TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
 (STATIC_DIR / "css").mkdir(parents=True, exist_ok=True) # For optional CSS
 
@@ -207,10 +209,22 @@ def _save_ai_config(cfg: Dict[str, Any]) -> None:
 
 def _atomic_write_json(path: Path, data: Dict[str, Any]) -> None:
     """Write JSON atomically to reduce corruption risk across workers."""
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    candidate_path = os.path.realpath(os.fspath(path))
+    config_path = os.path.realpath(os.fspath(CONFIG_PATH))
+    images_root = os.path.realpath(os.fspath(IMAGES_DIR))
+    is_config = candidate_path == config_path
+    is_image_sidecar = (
+        candidate_path.startswith(images_root + os.sep)
+        and candidate_path.lower().endswith(".json")
+    )
+    if not (is_config or is_image_sidecar):
+        raise ValueError("JSON destination is outside an approved storage root")
+
+    safe_path = Path(candidate_path)
+    tmp_path = safe_path.with_suffix(safe_path.suffix + ".tmp")
     text = json.dumps(data, indent=2, ensure_ascii=False)
     tmp_path.write_text(text, encoding="utf-8")
-    tmp_path.replace(path)
+    tmp_path.replace(safe_path)
 
 
 def _load_schema() -> Dict[str, Any]:
@@ -232,23 +246,50 @@ def _load_schema() -> Dict[str, Any]:
         }
 
 
-def _sanitize_filename(filename: str) -> str:
-    """Return a safe filename without directory traversal."""
-    return Path(filename).name
+def _sanitize_filename(filename: Optional[str]) -> str:
+    """Return a safe single-component filename or an empty string.
+
+    Filenames are identifiers in this application, not paths. Rejecting path
+    syntax instead of silently stripping it prevents ambiguous uploads and
+    gives static analysis a clear allowlist boundary.
+    """
+    candidate = (filename or "").strip()
+    if (
+        not candidate
+        or "\x00" in candidate
+        or "/" in candidate
+        or "\\" in candidate
+        or ".." in candidate
+        or candidate != os.path.basename(candidate)
+    ):
+        return ""
+    return candidate
 
 
 def _resolve_image_path(filename: str) -> Path:
-    """Return the resolved path inside IMAGES_DIR, raising 404 if the path escapes.
-
-    Strips any directory components from *filename* before joining so that
-    traversal sequences (e.g. ``../``) are discarded at the construction site,
-    not only at the containment-check site.
-    """
-    safe_name = Path(filename).name  # strip directory components first
-    resolved = (IMAGES_DIR / safe_name).resolve()
-    if not resolved.is_relative_to(IMAGES_DIR.resolve()):
+    """Return a normalized image path contained beneath ``IMAGES_DIR``."""
+    safe_name = _sanitize_filename(filename)
+    if not safe_name:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
-    return resolved
+
+    root_path = os.path.realpath(os.fspath(IMAGES_DIR))
+    full_path = os.path.realpath(os.path.join(root_path, safe_name))
+    if not full_path.startswith(root_path + os.sep):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+    return Path(full_path)
+
+
+def _resolve_import_path(candidate: str) -> Path:
+    """Resolve an admin import source strictly beneath ``IMPORT_ROOT``."""
+    root_path = os.path.realpath(os.fspath(IMPORT_ROOT))
+    expanded_candidate = os.path.expanduser(candidate.strip())
+    full_path = os.path.realpath(os.path.join(root_path, expanded_candidate))
+    if full_path != root_path and not full_path.startswith(root_path + os.sep):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Import path must be inside the configured import root",
+        )
+    return Path(full_path)
 
 
 def _allowed_image(filename: str) -> bool:
@@ -566,7 +607,8 @@ def _populate_missing_metadata(image_path: Path, metadata: Dict[str, Any]) -> Di
 
 def _ensure_sidecar(image_path: Path, metadata: Dict[str, Any]) -> None:
     """Ensure a JSON sidecar exists for the provided image with schema fields."""
-    json_path = image_path.with_suffix(".json")
+    safe_image_path = _resolve_image_path(image_path.name)
+    json_path = safe_image_path.with_suffix(".json")
     if json_path.exists():
         return
     schema = _load_schema()
@@ -589,12 +631,14 @@ def _ensure_sidecar(image_path: Path, metadata: Dict[str, Any]) -> None:
 
 
 def _write_sidecar(image_path: Path, metadata: Dict[str, Any]) -> None:
-    json_path = image_path.with_suffix(".json")
+    safe_image_path = _resolve_image_path(image_path.name)
+    json_path = safe_image_path.with_suffix(".json")
     with sidecar_lock:
         _atomic_write_json(json_path, metadata)
 
 def _set_review_status_sidecar(image_path: Path, reviewed: bool) -> None:
-    json_path = image_path.with_suffix(".json")
+    safe_image_path = _resolve_image_path(image_path.name)
+    json_path = safe_image_path.with_suffix(".json")
     data: Dict[str, Any] = {}
     if json_path.exists():
         with suppress(json.JSONDecodeError, OSError):
@@ -742,6 +786,7 @@ def _verify_admin(
 
 def _load_metadata(image_path: Path) -> Dict[str, Any]:
     """Load metadata for an image, combining sidecar data and EXIF hints."""
+    image_path = _resolve_image_path(image_path.name)
     data: Dict[str, Any] = {}
     json_path = image_path.with_suffix(".json")
     if json_path.exists():
@@ -1009,8 +1054,9 @@ async def regenerate_ai_metadata(
             meta = _populate_missing_metadata(path, meta)
             _write_sidecar(path, meta)
             updated.append({"name": fname, "metadata": meta})
-        except Exception as exc:
-            errors.append({"name": name, "error": str(exc)})
+        except Exception:
+            logger.exception("Failed to regenerate metadata for %s", fname)
+            errors.append({"name": fname, "error": "Metadata regeneration failed"})
 
     return JSONResponse({"updated": updated, "errors": errors, "pending": pending_dependency})
 
@@ -1091,7 +1137,7 @@ async def import_from_path(
     pending_dependency: List[Dict[str, Any]] = Depends(get_pending_files),
     _: None = Depends(_verify_admin),
 ) -> JSONResponse:
-    source_path = Path(path).expanduser()
+    source_path = _resolve_import_path(path)
     if not source_path.exists():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Path does not exist")
 
@@ -1100,8 +1146,8 @@ async def import_from_path(
 
     def _handle_file(file_path: Path) -> None:
         target_name = _sanitize_filename(file_path.name)
-        if _allowed_image(target_name) or file_path.suffix.lower() == ".json":
-            target = IMAGES_DIR / target_name
+        if target_name and (_allowed_image(target_name) or file_path.suffix.lower() == ".json"):
+            target = _resolve_image_path(target_name)
             try:
                 shutil.copy2(file_path, target)
                 copied.append(target_name)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,15 @@
 import base64
+import asyncio
 import io
 import json
 import os
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 
+import main as gallery_app
 from main import app, IMAGES_DIR, ALLOWED_IMAGE_EXTENSIONS
 
 
@@ -140,3 +144,103 @@ def test_upload_rejects_svg(authed_client):
     data = response.json()
     assert "evil.svg" in data.get("skipped", [])
     assert "evil.svg" not in data.get("saved", [])
+
+
+# ---------------------------------------------------------------------------
+# Filesystem containment
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "filename",
+    ["../secret.jpg", "nested/secret.jpg", r"nested\secret.jpg", "..secret.jpg"],
+)
+def test_sanitize_filename_rejects_path_syntax(filename):
+    assert gallery_app._sanitize_filename(filename) == ""
+
+
+def test_resolve_image_path_rejects_escape_and_symlink(monkeypatch, tmp_path):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    outside = tmp_path / "outside.jpg"
+    outside.touch()
+    (image_root / "escape.jpg").symlink_to(outside)
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+
+    assert gallery_app._resolve_image_path("safe.jpg") == image_root / "safe.jpg"
+    for candidate in ("../outside.jpg", str(outside), "escape.jpg"):
+        with pytest.raises(HTTPException) as exc_info:
+            gallery_app._resolve_image_path(candidate)
+        assert exc_info.value.status_code == 404
+
+
+def test_resolve_import_path_stays_within_configured_root(monkeypatch, tmp_path):
+    import_root = tmp_path / "imports"
+    import_root.mkdir()
+    nested = import_root / "batch"
+    nested.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (import_root / "escape").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(gallery_app, "IMPORT_ROOT", import_root)
+
+    assert gallery_app._resolve_import_path("batch") == nested
+    assert gallery_app._resolve_import_path(str(nested)) == nested
+    for candidate in ("../outside", str(outside), "escape"):
+        with pytest.raises(HTTPException) as exc_info:
+            gallery_app._resolve_import_path(candidate)
+        assert exc_info.value.status_code == 400
+
+
+def test_atomic_json_write_rejects_unapproved_destination(monkeypatch, tmp_path):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+
+    sidecar = image_root / "safe.json"
+    gallery_app._atomic_write_json(sidecar, {"title": "Safe"})
+    assert json.loads(sidecar.read_text(encoding="utf-8")) == {"title": "Safe"}
+
+    with pytest.raises(ValueError, match="outside an approved storage root"):
+        gallery_app._atomic_write_json(tmp_path / "outside.json", {"secret": True})
+
+
+def test_regenerate_metadata_does_not_expose_exception_details(monkeypatch, tmp_path):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    (image_root / "safe.jpg").touch()
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+
+    secret_detail = "/srv/private/secret-key.txt"
+
+    def fail_metadata(*_args, **_kwargs):
+        raise RuntimeError(secret_detail)
+
+    monkeypatch.setattr(gallery_app, "_populate_missing_metadata", fail_metadata)
+    body = json.dumps({"images": ["safe.jpg"]}).encode("utf-8")
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/admin/ai/regenerate",
+            "headers": [(b"content-type", b"application/json")],
+            "app": app,
+        },
+        receive,
+    )
+    response = asyncio.run(
+        gallery_app.regenerate_ai_metadata(
+            request,
+            pending_dependency=[],
+            _=None,
+        )
+    )
+    payload = json.loads(response.body)
+
+    assert payload["errors"] == [
+        {"name": "safe.jpg", "error": "Metadata regeneration failed"}
+    ]
+    assert secret_detail not in response.body.decode("utf-8")


### PR DESCRIPTION
## Summary

Fixes every CodeQL finding currently blocking production promotion PR #37, in severity order.

### High: path injection
- reject traversal and path syntax in image filenames instead of silently normalizing it
- normalize image paths with `realpath` and enforce containment beneath `IMAGES_DIR`
- enforce approved roots for atomic JSON writes and all sidecar helpers
- restrict `/admin/import-path` sources to the configured `IMPORT_ROOT`
- reject symlink escapes for image and import paths

### Medium: exception exposure
- keep detailed regeneration exceptions in server logs
- return a stable generic client error instead of raw `str(exc)`

### Configuration
- document `IMPORT_ROOT` for local, Railway production, and PR preview environments
- ignore the local `imports/` staging directory

## Validation
- `.venv/bin/pytest tests -q`: 17 passed
- Python compilation: passed
- `git diff --check`: passed
- Semgrep Python rules: 151 run, 0 findings

This PR should clear the CodeQL policy gate on #37 once merged into `dev`.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

