### PR TITLE
Eliminate residual CodeQL import and exception flows

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import time
 import textwrap
 from contextlib import asynccontextmanager, suppress
 from io import BytesIO
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional
 
 import secrets
@@ -279,17 +279,50 @@ def _resolve_image_path(filename: str) -> Path:
     return Path(full_path)
 
 
-def _resolve_import_path(candidate: str) -> Path:
-    """Resolve an admin import source strictly beneath ``IMPORT_ROOT``."""
-    root_path = os.path.realpath(os.fspath(IMPORT_ROOT))
-    expanded_candidate = os.path.expanduser(candidate.strip())
-    full_path = os.path.realpath(os.path.join(root_path, expanded_candidate))
-    if full_path != root_path and not full_path.startswith(root_path + os.sep):
+def _select_import_files(candidate: str) -> List[Path]:
+    """Select import files from an allowlist enumerated beneath ``IMPORT_ROOT``.
+
+    The request value is used only to match relative path components; it is
+    never used to construct or access a filesystem path.
+    """
+    requested = candidate.strip().replace("\\", "/")
+    requested_path = PurePosixPath(requested)
+    if (
+        not requested
+        or "\x00" in requested
+        or requested_path.is_absolute()
+        or ".." in requested_path.parts
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Import path must be inside the configured import root",
+            detail="Import path must be relative to the configured import root",
         )
-    return Path(full_path)
+
+    requested_parts = () if requested_path == PurePosixPath(".") else requested_path.parts
+    root_path = os.path.realpath(os.fspath(IMPORT_ROOT))
+    root = Path(root_path)
+    selected: List[Path] = []
+    for discovered_path in root.rglob("*"):
+        full_path = os.path.realpath(os.fspath(discovered_path))
+        if not full_path.startswith(root_path + os.sep):
+            continue
+        safe_path = Path(full_path)
+        if not safe_path.is_file():
+            continue
+        relative_parts = safe_path.relative_to(root).parts
+        if (
+            not requested_parts
+            or relative_parts == requested_parts
+            or relative_parts[: len(requested_parts)] == requested_parts
+        ):
+            selected.append(safe_path)
+
+    if not selected:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Import path does not exist inside the configured import root",
+        )
+    return sorted(selected)
 
 
 def _allowed_image(filename: str) -> bool:
@@ -491,13 +524,10 @@ def _request_openai_metadata(
             response.raise_for_status()
             payload = response.json()
     except (httpx.HTTPError, json.JSONDecodeError) as exc:
+        logger.warning("OpenAI metadata request failed: %s", exc)
         details["status"] = "error_http"
-        details["error"] = str(exc)
-        # Attach response body when available for diagnostics
-        try:
-            details["error_body"] = response.text
-        except Exception:
-            pass
+        details["error"] = "OpenAI metadata request failed."
+        details["error_body"] = ""
         return {"title": "", "description": "", "details": details}
 
     details["response_id"] = payload.get("id", "")
@@ -541,8 +571,9 @@ def _request_openai_metadata(
         try:
             parsed = json.loads(content_text) if content_text else None
         except json.JSONDecodeError as exc:
+            logger.warning("Unable to parse OpenAI metadata response: %s", exc)
             details["status"] = "error_parse"
-            details["error"] = f"Failed to parse OpenAI response: {exc}"
+            details["error"] = "OpenAI metadata response could not be parsed."
             # attach brief output excerpt and types for debugging
             try:
                 details["raw_response"] = {
@@ -1137,14 +1168,12 @@ async def import_from_path(
     pending_dependency: List[Dict[str, Any]] = Depends(get_pending_files),
     _: None = Depends(_verify_admin),
 ) -> JSONResponse:
-    source_path = _resolve_import_path(path)
-    if not source_path.exists():
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Path does not exist")
+    source_files = _select_import_files(path)
 
     copied: List[str] = []
     skipped: List[str] = []
 
-    def _handle_file(file_path: Path) -> None:
+    for file_path in source_files:
         target_name = _sanitize_filename(file_path.name)
         if target_name and (_allowed_image(target_name) or file_path.suffix.lower() == ".json"):
             target = _resolve_image_path(target_name)
@@ -1158,13 +1187,6 @@ async def import_from_path(
                 skipped.append(target_name)
         else:
             skipped.append(target_name)
-
-    if source_path.is_file():
-        _handle_file(source_path)
-    else:
-        for file_path in source_path.rglob("*"):
-            if file_path.is_file():
-                _handle_file(file_path)
 
     return JSONResponse({"copied": copied, "skipped": skipped, "pending": pending_dependency})
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -173,21 +173,26 @@ def test_resolve_image_path_rejects_escape_and_symlink(monkeypatch, tmp_path):
         assert exc_info.value.status_code == 404
 
 
-def test_resolve_import_path_stays_within_configured_root(monkeypatch, tmp_path):
+def test_select_import_files_uses_root_allowlist(monkeypatch, tmp_path):
     import_root = tmp_path / "imports"
     import_root.mkdir()
     nested = import_root / "batch"
     nested.mkdir()
+    safe_file = nested / "safe.jpg"
+    safe_file.touch()
     outside = tmp_path / "outside"
     outside.mkdir()
-    (import_root / "escape").symlink_to(outside, target_is_directory=True)
+    outside_file = outside / "secret.jpg"
+    outside_file.touch()
+    (import_root / "escape.jpg").symlink_to(outside_file)
     monkeypatch.setattr(gallery_app, "IMPORT_ROOT", import_root)
 
-    assert gallery_app._resolve_import_path("batch") == nested
-    assert gallery_app._resolve_import_path(str(nested)) == nested
-    for candidate in ("../outside", str(outside), "escape"):
+    assert gallery_app._select_import_files("batch") == [safe_file]
+    assert gallery_app._select_import_files("batch/safe.jpg") == [safe_file]
+    assert gallery_app._select_import_files(".") == [safe_file]
+    for candidate in ("../outside", str(outside), "escape.jpg"):
         with pytest.raises(HTTPException) as exc_info:
-            gallery_app._resolve_import_path(candidate)
+            gallery_app._select_import_files(candidate)
         assert exc_info.value.status_code == 400
 
 
@@ -244,3 +249,79 @@ def test_regenerate_metadata_does_not_expose_exception_details(monkeypatch, tmp_
         {"name": "safe.jpg", "error": "Metadata regeneration failed"}
     ]
     assert secret_detail not in response.body.decode("utf-8")
+
+
+def test_openai_http_error_details_are_not_exposed(monkeypatch, tmp_path):
+    image_path = tmp_path / "safe.jpg"
+    image_path.touch()
+    secret_detail = "/srv/private/openai-response.txt"
+
+    class FailingClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def post(self, *_args, **_kwargs):
+            request = gallery_app.httpx.Request("POST", "https://api.openai.com/v1/responses")
+            raise gallery_app.httpx.ConnectError(secret_detail, request=request)
+
+    monkeypatch.setattr(gallery_app, "_get_openai_api_key", lambda: "test-key")
+    monkeypatch.setattr(gallery_app, "_prepare_image_for_openai", lambda _path: "data:image/jpeg;base64,eA==")
+    monkeypatch.setattr(gallery_app.httpx, "Client", FailingClient)
+
+    result = gallery_app._request_openai_metadata(image_path, {}, True, True)
+    details = result["details"]
+
+    assert details["error"] == "OpenAI metadata request failed."
+    assert details["error_body"] == ""
+    assert secret_detail not in json.dumps(result)
+
+
+def test_openai_parse_error_details_are_not_exposed(monkeypatch, tmp_path):
+    image_path = tmp_path / "safe.jpg"
+    image_path.touch()
+    secret_detail = "/srv/private/invalid-response.txt"
+
+    class InvalidJsonResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "id": "response-id",
+                "model": "test-model",
+                "output": [
+                    {
+                        "content": [
+                            {"type": "output_text", "text": f"not-json {secret_detail}"}
+                        ]
+                    }
+                ],
+            }
+
+    class InvalidJsonClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def post(self, *_args, **_kwargs):
+            return InvalidJsonResponse()
+
+    monkeypatch.setattr(gallery_app, "_get_openai_api_key", lambda: "test-key")
+    monkeypatch.setattr(gallery_app, "_prepare_image_for_openai", lambda _path: "data:image/jpeg;base64,eA==")
+    monkeypatch.setattr(gallery_app.httpx, "Client", InvalidJsonClient)
+
+    result = gallery_app._request_openai_metadata(image_path, {}, True, True)
+
+    assert result["details"]["error"] == "OpenAI metadata response could not be parsed."
+    assert secret_detail not in result["details"]["error"]


### PR DESCRIPTION
## Summary

Follow-up to #39 for the five flows revealed when production PR #37 re-ran against its full historical diff.

- decouple admin import requests from filesystem path construction
- enumerate files beneath `IMPORT_ROOT` first, then match request values only against relative path components
- skip symlinks that resolve outside the import root
- replace OpenAI HTTP and JSON parse exception details with generic client-visible errors
- preserve detailed diagnostics in server logs

## Validation

- `.venv/bin/pytest tests -q`: 19 passed
- Python compilation: passed
- `git diff --check`: passed
- Semgrep Python rules: 151 run, 0 findings

This targets the residual CodeQL alerts #15–#18 and the refreshed exception-exposure flow on #37.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

