### PR TITLE
Address final production PR review comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -948,6 +948,11 @@ async def get_pending_files(request: Request) -> List[Dict[str, Any]]:
     FastAPI dependency to get the list of pending files.
     This runs before routes that depend on it.
     """
+    return _refresh_pending_files(request)
+
+
+def _refresh_pending_files(request: Request) -> List[Dict[str, Any]]:
+    """Re-scan pending images and keep the application cache in sync."""
     pending = new_files_detected()
     request.app.state.pending_images = pending
     return pending
@@ -1054,7 +1059,6 @@ async def reset_admin_config(
 @app.post("/admin/ai/regenerate", response_class=JSONResponse)
 async def regenerate_ai_metadata(
     request: Request,
-    pending_dependency: List[Dict[str, Any]] = Depends(get_pending_files),
     _: None = Depends(_verify_admin),
 ) -> JSONResponse:
     try:
@@ -1089,14 +1093,14 @@ async def regenerate_ai_metadata(
             logger.exception("Failed to regenerate metadata for %s", fname)
             errors.append({"name": fname, "error": "Metadata regeneration failed"})
 
-    return JSONResponse({"updated": updated, "errors": errors, "pending": pending_dependency})
+    pending = _refresh_pending_files(request)
+    return JSONResponse({"updated": updated, "errors": errors, "pending": pending})
 
 
 @app.post("/admin/upload")
 async def upload_images(
     request: Request,
     files: List[UploadFile] = File(...),
-    pending_dependency: List[Dict[str, Any]] = Depends(get_pending_files),
     _: None = Depends(_verify_admin),
 ) -> JSONResponse:
     if not files:
@@ -1117,7 +1121,8 @@ async def upload_images(
         destination = _resolve_image_path(filename)
         try:
             # Fast pre-check using Content-Length / spooled size when available
-            if upload.size is not None and upload.size > MAX_UPLOAD_SIZE_BYTES:
+            upload_size = getattr(upload, "size", None)
+            if upload_size is not None and upload_size > MAX_UPLOAD_SIZE_BYTES:
                 logger.warning(
                     "Upload rejected: %s exceeds size limit (%d MB)",
                     filename,
@@ -1158,14 +1163,14 @@ async def upload_images(
             upload.file.close()
 
     message = "Uploaded files successfully" if saved else "No supported files uploaded"
-    return JSONResponse({"saved": saved, "skipped": skipped, "message": message, "pending": pending_dependency})
+    pending = _refresh_pending_files(request)
+    return JSONResponse({"saved": saved, "skipped": skipped, "message": message, "pending": pending})
 
 
 @app.post("/admin/import-path")
 async def import_from_path(
     request: Request,
     path: str = Form(...),
-    pending_dependency: List[Dict[str, Any]] = Depends(get_pending_files),
     _: None = Depends(_verify_admin),
 ) -> JSONResponse:
     source_files = _select_import_files(path)
@@ -1188,7 +1193,8 @@ async def import_from_path(
         else:
             skipped.append(target_name)
 
-    return JSONResponse({"copied": copied, "skipped": skipped, "pending": pending_dependency})
+    pending = _refresh_pending_files(request)
+    return JSONResponse({"copied": copied, "skipped": skipped, "pending": pending})
 
 
 @app.get("/admin/review/{image_name}", response_class=HTMLResponse)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -221,6 +221,11 @@ def test_regenerate_metadata_does_not_expose_exception_details(monkeypatch, tmp_
         raise RuntimeError(secret_detail)
 
     monkeypatch.setattr(gallery_app, "_populate_missing_metadata", fail_metadata)
+    monkeypatch.setattr(
+        gallery_app,
+        "_refresh_pending_files",
+        lambda _request: [{"name": "fresh-state.jpg"}],
+    )
     body = json.dumps({"images": ["safe.jpg"]}).encode("utf-8")
 
     async def receive():
@@ -239,7 +244,6 @@ def test_regenerate_metadata_does_not_expose_exception_details(monkeypatch, tmp_
     response = asyncio.run(
         gallery_app.regenerate_ai_metadata(
             request,
-            pending_dependency=[],
             _=None,
         )
     )
@@ -248,7 +252,83 @@ def test_regenerate_metadata_does_not_expose_exception_details(monkeypatch, tmp_
     assert payload["errors"] == [
         {"name": "safe.jpg", "error": "Metadata regeneration failed"}
     ]
+    assert payload["pending"] == [{"name": "fresh-state.jpg"}]
     assert secret_detail not in response.body.decode("utf-8")
+
+
+def test_upload_without_size_attribute_uses_streaming_limit(monkeypatch, tmp_path):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+    monkeypatch.setattr(gallery_app, "_refresh_pending_files", lambda _request: [])
+
+    class UploadWithoutSize:
+        filename = "no-size.png"
+
+        def __init__(self):
+            self.file = io.BytesIO(b"small image payload")
+
+        async def read(self, size):
+            return self.file.read(size)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/admin/upload",
+            "headers": [],
+            "app": app,
+        }
+    )
+    response = asyncio.run(
+        gallery_app.upload_images(
+            request,
+            files=[UploadWithoutSize()],
+            _=None,
+        )
+    )
+    payload = json.loads(response.body)
+
+    assert payload["saved"] == ["no-size.png"]
+    assert (image_root / "no-size.png").exists()
+
+
+def test_import_returns_refreshed_pending_state(monkeypatch, tmp_path):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    import_root = tmp_path / "imports"
+    batch = import_root / "batch"
+    batch.mkdir(parents=True)
+    (batch / "imported.jpg").touch()
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+    monkeypatch.setattr(gallery_app, "IMPORT_ROOT", import_root)
+    monkeypatch.setattr(
+        gallery_app,
+        "_refresh_pending_files",
+        lambda _request: [{"name": "fresh-state.jpg"}],
+    )
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/admin/import-path",
+            "headers": [],
+            "app": app,
+        }
+    )
+
+    response = asyncio.run(
+        gallery_app.import_from_path(
+            request,
+            path="batch",
+            _=None,
+        )
+    )
+    payload = json.loads(response.body)
+
+    assert payload["copied"] == ["imported.jpg"]
+    assert payload["pending"] == [{"name": "fresh-state.jpg"}]
+    assert (image_root / "imported.jpg").exists()
 
 
 def test_openai_http_error_details_are_not_exposed(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Addresses the two outstanding Copilot comments on production PR #37.

- use `getattr(upload, "size", None)` so uploads work with Starlette versions where `UploadFile.size` is absent
- remove pre-mutation pending dependencies from regenerate/upload/import routes
- refresh and cache pending state after each mutation so responses immediately reflect new sidecars and metadata
- add regression coverage for size-less uploads and refreshed regeneration/import responses

## Validation

- `.venv/bin/pytest tests -q`: 21 passed
- Python compilation: passed
- `git diff --check`: passed
- Semgrep Python rules: 151 run, 0 findings
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

