### PR TITLE
Document production infrastructure: artazzen.com on Railway + Cloudflare

### DIFF
--- a/BRANCHING_STRATEGY.md
+++ b/BRANCHING_STRATEGY.md
@@ -71,11 +71,13 @@ Railway supports multiple environments tied to branches. Each environment has it
 
 ### Production (`main`)
 
-- **Branch**: `main`
-- **Auto-deploy**: on push/merge to `main`
+- **URL**: https://artazzen.com (canonical apex domain)
+- **Branch**: `main` — auto-deploys on push/merge
+- **Hosting**: Dedicated Railway project
+- **DNS**: Cloudflare nameservers. `www.artazzen.com` → 301 redirect to apex via Cloudflare rule. `www` A record points to Cloudflare proxy internal IP.
+- **CDN/Proxy**: Cloudflare proxy on apex — SSL termination, DDoS protection, caching
 - **Volume**: persistent storage mounted at `/data/images` (`IMAGES_DIR=/data/images`)
 - **Variables**: `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `MY_OPENAI_API_KEY`, and other production secrets set in Railway dashboard
-- **Domain**: production URL configured in Railway
 
 ### PR Deploy Previews (planned)
 

--- a/BRANCHING_STRATEGY.md
+++ b/BRANCHING_STRATEGY.md
@@ -74,7 +74,7 @@ Railway supports multiple environments tied to branches. Each environment has it
 - **URL**: https://artazzen.com (canonical apex domain)
 - **Branch**: `main` — auto-deploys on push/merge
 - **Hosting**: Dedicated Railway project
-- **DNS**: Cloudflare nameservers. `www.artazzen.com` → 301 redirect to apex via Cloudflare rule. `www` A record points to Cloudflare proxy internal IP.
+- **DNS**: Cloudflare nameservers. `www.artazzen.com` → 301 redirect to apex via Cloudflare rule. `www` uses a proxied DNS record that resolves through Cloudflare edge IPs.
 - **CDN/Proxy**: Cloudflare proxy on apex — SSL termination, DDoS protection, caching
 - **Volume**: persistent storage mounted at `/data/images` (`IMAGES_DIR=/data/images`)
 - **Variables**: `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `MY_OPENAI_API_KEY`, and other production secrets set in Railway dashboard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,14 @@ Direct pushes to `dev` and `main` are **blocked** by GitHub rulesets. All change
 
 ## Deployment
 
-Deployed on **Railway** via Procfile: `uvicorn main:app --host 0.0.0.0 --port $PORT --proxy-headers`
+**Production**: https://artazzen.com — deployed on Railway, auto-deploys from `main`.
+
+### Infrastructure
+
+- **Hosting**: Railway (dedicated project), Procfile: `uvicorn main:app --host 0.0.0.0 --port $PORT --proxy-headers`
+- **DNS**: Cloudflare nameservers. Apex domain (`artazzen.com`) is canonical.
+- **www redirect**: `www.artazzen.com` → `artazzen.com` via Cloudflare 301 permanent redirect rule. `www` is an A record pointing to a Cloudflare proxy internal IP.
+- **CDN/Proxy**: Cloudflare proxy enabled on apex — provides SSL termination, DDoS protection, and caching.
 
 ### Railway Volume
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,9 +131,9 @@ Direct pushes to `dev` and `main` are **blocked** by GitHub rulesets. All change
 
 ### Infrastructure
 
-- **Hosting**: Railway (dedicated project), Procfile: `uvicorn main:app --host 0.0.0.0 --port $PORT --proxy-headers`
+- **Hosting**: Railway (dedicated project), Procfile: `uvicorn main:app --host 0.0.0.0 --port $PORT --proxy-headers --forwarded-allow-ips="*"`
 - **DNS**: Cloudflare nameservers. Apex domain (`artazzen.com`) is canonical.
-- **www redirect**: `www.artazzen.com` → `artazzen.com` via Cloudflare 301 permanent redirect rule. `www` is an A record pointing to a Cloudflare proxy internal IP.
+- **www redirect**: `www.artazzen.com` → `artazzen.com` via Cloudflare 301 permanent redirect rule. `www` uses a proxied DNS record that resolves through Cloudflare edge IPs.
 - **CDN/Proxy**: Cloudflare proxy enabled on apex — provides SSL termination, DDoS protection, and caching.
 
 ### Railway Volume


### PR DESCRIPTION
## Summary
- Update `CLAUDE.md` deployment section with live production URL, Cloudflare DNS/proxy details, and www→apex 301 redirect
- Update `BRANCHING_STRATEGY.md` production environment with full infrastructure details (Railway project, Cloudflare, domain config)

## Verified
- `https://artazzen.com` → 200 OK (Cloudflare + Railway headers confirmed)
- `https://www.artazzen.com` → 301 redirect to `https://artazzen.com/`
- `/admin` → 401 with `WWW-Authenticate: Basic realm="Artwork Admin"`
- Security headers: X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy strict-origin-when-cross-origin

## Test plan
- [ ] Verify docs accurately reflect the live infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147Vq9oNTpzMzmNPEeySZd3
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

