### PR TITLE
feat: admin gallery curation with status enum

### DIFF
--- a/ImageSidecar.schema.json
+++ b/ImageSidecar.schema.json
@@ -69,9 +69,16 @@
         }
       }
     },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "approved", "hidden"],
+      "default": "pending",
+      "description": "Curation status of the artwork."
+    },
     "reviewed": {
       "type": "boolean",
-      "default": false
+      "default": false,
+      "description": "Deprecated: use status field instead. Kept for backwards compatibility."
     },
     "detected_at": {
       "type": "number",
@@ -84,7 +91,7 @@
     "description",
     "ai_generated",
     "ai_details",
-    "reviewed",
+    "status",
     "detected_at"
   ]
 }

--- a/Static/css/styles.css
+++ b/Static/css/styles.css
@@ -184,9 +184,143 @@ main {
 }
 
 .admin-container {
-    display: grid;
-    grid-template-columns: 1fr 2fr;
+    display: flex;
+    flex-direction: column;
     gap: 2rem;
+}
+
+.admin-search {
+    position: relative;
+    max-width: 480px;
+}
+
+.admin-search input {
+    width: 100%;
+    padding: 0.75rem 1rem 0.75rem 2.5rem;
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-main);
+    font-family: var(--font-body);
+    font-size: 0.875rem;
+    border-radius: var(--radius-sm);
+}
+
+.admin-search input:focus {
+    outline: none;
+    border-color: var(--text-main);
+}
+
+.admin-search::before {
+    content: "\1F50D";
+    position: absolute;
+    left: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0.875rem;
+    opacity: 0.4;
+}
+
+.admin-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1.5rem;
+}
+
+.admin-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    transition: border-color 0.2s ease;
+}
+
+.admin-card:hover {
+    border-color: var(--text-main);
+}
+
+.admin-card img {
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: cover;
+    display: block;
+}
+
+.admin-card-info {
+    padding: 1rem;
+}
+
+.admin-card-info h3 {
+    font-family: var(--font-heading);
+    font-size: 0.875rem;
+    margin: 0 0 0.25rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.admin-card-info .filename {
+    margin: 0 0 0.75rem;
+}
+
+.admin-card-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.admin-card-actions .button {
+    font-size: 0.65rem;
+    padding: 0.4rem 0.75rem;
+}
+
+.button.danger {
+    border-color: var(--accent-orange);
+    color: var(--accent-orange);
+    background: transparent;
+}
+
+.button.danger:hover {
+    background: var(--accent-orange);
+    color: white;
+}
+
+.admin-tabs {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 2rem;
+}
+
+.admin-tab {
+    font-family: var(--font-heading);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    padding: 0.75rem 1.5rem;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s ease;
+}
+
+.admin-tab:hover {
+    color: var(--text-main);
+}
+
+.admin-tab.active {
+    color: var(--text-main);
+    border-bottom-color: var(--text-main);
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
 }
 
 .admin-panel {
@@ -429,8 +563,8 @@ footer {
 
 /* Responsive */
 @media (max-width: 900px) {
-    .admin-container {
-        grid-template-columns: 1fr;
+    .admin-grid {
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
     }
     header h1 {
         font-size: 3rem;

--- a/main.py
+++ b/main.py
@@ -147,6 +147,15 @@ def _parse_bool_env(value: Optional[str], default: bool) -> bool:
         return default
 
 
+def _coerce_bool(value: Any) -> bool:
+    """Safely coerce a bool or string to a Python bool."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "y"}
+    return bool(value)
+
+
 def _parse_float_env(value: Optional[str], default: float) -> float:
     if value is None:
         return default
@@ -656,7 +665,7 @@ def _ensure_sidecar(image_path: Path, metadata: Dict[str, Any]) -> None:
     sidecar_data["ai_generated"] = bool(metadata.get("ai_generated", False))
     sidecar_ai_details = metadata.get("ai_details") if isinstance(metadata.get("ai_details"), dict) else {}
     sidecar_data["ai_details"] = sidecar_ai_details
-    sidecar_data["status"] = metadata.get("status", "approved" if metadata.get("reviewed") else "pending")
+    sidecar_data["status"] = metadata.get("status", "approved" if _coerce_bool(metadata.get("reviewed", False)) else "pending")
     sidecar_data["detected_at"] = float(metadata.get("detected_at", now))
     with sidecar_lock:
         _atomic_write_json(json_path, sidecar_data)
@@ -841,7 +850,7 @@ def _load_metadata(image_path: Path) -> Dict[str, Any]:
     data.setdefault("title", "")
     data.setdefault("description", "")
     if "status" not in data and "reviewed" in data:
-        data["status"] = "approved" if data["reviewed"] else "pending"
+        data["status"] = "approved" if _coerce_bool(data["reviewed"]) else "pending"
     data.setdefault("status", "pending")
     data.setdefault("detected_at", time.time())
     data.setdefault("ai_generated", False)

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ IMAGES_DIR = Path(os.getenv("IMAGES_DIR", STATIC_DIR / "images"))
 _USING_VOLUME = IMAGES_DIR != STATIC_DIR / "images"
 IMAGES_URL_PREFIX = "/images" if _USING_VOLUME else "/static/images"
 IMPORT_ROOT = Path(os.getenv("IMPORT_ROOT", BASE_DIR / "imports"))
+GALLERY_TITLE = os.getenv("GALLERY_TITLE", "Artazzen Gallery")
 TEMPLATES_DIR = BASE_DIR / "templates"
 SCHEMA_PATH = BASE_DIR / "ImageSidecar.schema.json"
 CONFIG_PATH = BASE_DIR / "ai_config.json"
@@ -238,10 +239,10 @@ def _load_schema() -> Dict[str, Any]:
             "properties": {
                 "title": {"type": "string", "default": ""},
                 "description": {"type": "string", "default": ""},
-                "reviewed": {"type": "boolean", "default": False},
+                "status": {"type": "string", "enum": ["pending", "approved", "hidden"], "default": "pending"},
                 "detected_at": {"type": "number", "default": 0},
             },
-            "required": ["title", "description", "reviewed", "detected_at"],
+            "required": ["title", "description", "status", "detected_at"],
             "additionalProperties": False,
         }
 
@@ -631,7 +632,7 @@ def _populate_missing_metadata(image_path: Path, metadata: Dict[str, Any]) -> Di
         metadata.setdefault("ai_generated", False)
 
     metadata.setdefault("detected_at", time.time())
-    metadata.setdefault("reviewed", False)
+    metadata.setdefault("status", "pending")
     _write_sidecar(image_path, metadata)
     return metadata
 
@@ -655,7 +656,7 @@ def _ensure_sidecar(image_path: Path, metadata: Dict[str, Any]) -> None:
     sidecar_data["ai_generated"] = bool(metadata.get("ai_generated", False))
     sidecar_ai_details = metadata.get("ai_details") if isinstance(metadata.get("ai_details"), dict) else {}
     sidecar_data["ai_details"] = sidecar_ai_details
-    sidecar_data["reviewed"] = bool(metadata.get("reviewed", False))
+    sidecar_data["status"] = metadata.get("status", "approved" if metadata.get("reviewed") else "pending")
     sidecar_data["detected_at"] = float(metadata.get("detected_at", now))
     with sidecar_lock:
         _atomic_write_json(json_path, sidecar_data)
@@ -667,14 +668,14 @@ def _write_sidecar(image_path: Path, metadata: Dict[str, Any]) -> None:
     with sidecar_lock:
         _atomic_write_json(json_path, metadata)
 
-def _set_review_status_sidecar(image_path: Path, reviewed: bool) -> None:
+def _set_status_sidecar(image_path: Path, new_status: str) -> None:
     safe_image_path = _resolve_image_path(image_path.name)
     json_path = safe_image_path.with_suffix(".json")
     data: Dict[str, Any] = {}
     if json_path.exists():
         with suppress(json.JSONDecodeError, OSError):
             data = json.loads(json_path.read_text(encoding="utf-8"))
-    data["reviewed"] = reviewed
+    data["status"] = new_status
     data.setdefault("title", "")
     data.setdefault("description", "")
     data.setdefault("ai_generated", False)
@@ -685,7 +686,7 @@ def _set_review_status_sidecar(image_path: Path, reviewed: bool) -> None:
 
 
 def new_files_detected() -> List[Dict[str, Any]]:
-    """Detect unreviewed image files based on their sidecar JSON."""
+    """Detect pending image files based on their sidecar JSON status."""
     pending: List[Dict[str, Any]] = []
     try:
         disk_listing = os.listdir(IMAGES_DIR)
@@ -703,7 +704,7 @@ def new_files_detected() -> List[Dict[str, Any]]:
         _ensure_sidecar(image_path, metadata)
         metadata = _load_metadata(image_path)
         metadata = _populate_missing_metadata(image_path, metadata)
-        if not bool(metadata.get("reviewed", False)):
+        if metadata.get("status", "pending") == "pending":
             pending.append(
                 {
                     "name": filename,
@@ -722,8 +723,11 @@ async def _watch_image_directory(app: FastAPI) -> None:
     """Background task that polls for new files."""
     try:
         while True:
-            pending = new_files_detected()
-            app.state.pending_images = pending
+            try:
+                pending = new_files_detected()
+                app.state.pending_images = pending
+            except FileNotFoundError:
+                logger.debug("File disappeared during watcher scan, will retry next cycle")
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
     except asyncio.CancelledError:  # pragma: no cover - clean shutdown
         logger.debug("Image directory watcher cancelled")
@@ -836,7 +840,9 @@ def _load_metadata(image_path: Path) -> Dict[str, Any]:
 
     data.setdefault("title", "")
     data.setdefault("description", "")
-    data.setdefault("reviewed", False)
+    if "status" not in data and "reviewed" in data:
+        data["status"] = "approved" if data["reviewed"] else "pending"
+    data.setdefault("status", "pending")
     data.setdefault("detected_at", time.time())
     data.setdefault("ai_generated", False)
     if not isinstance(data.get("ai_details"), dict):
@@ -863,12 +869,8 @@ def _apply_schema_defaults(data: Dict[str, Any], schema: Dict[str, Any]) -> Dict
             else:
                 data[key] = None
     # Simple coercions
-    if isinstance(data.get("reviewed"), str):
-        lowered = data["reviewed"].strip().lower()
-        if lowered in {"true", "1", "yes", "y"}:
-            data["reviewed"] = True
-        elif lowered in {"false", "0", "no", "n"}:
-            data["reviewed"] = False
+    if "status" in data and data["status"] not in ("pending", "approved", "hidden"):
+        data["status"] = "pending"
     if isinstance(data.get("ai_generated"), str):
         lowered = data["ai_generated"].strip().lower()
         if lowered in {"true", "1", "yes", "y"}:
@@ -919,8 +921,8 @@ def _validate_and_migrate_sidecars() -> None:
 
 
 # --- Helper Function ---
-def get_artwork_files():
-    """Scan IMAGES_DIR and return metadata for each image."""
+def get_artwork_files(*, status_filter: str = "approved"):
+    """Scan IMAGES_DIR and return metadata for images matching status_filter."""
     artwork = []
     logger.info(f"Scanning for artwork in: {IMAGES_DIR}")
     if IMAGES_DIR.exists() and IMAGES_DIR.is_dir():
@@ -929,6 +931,8 @@ def get_artwork_files():
                 file_path = IMAGES_DIR / filename
                 if file_path.is_file() and _allowed_image(filename):
                     meta = _load_metadata(file_path)
+                    if status_filter and meta.get("status", "pending") != status_filter:
+                        continue
                     image_url = f"{IMAGES_URL_PREFIX}/{filename}"
                     meta.update({"url": image_url, "name": filename})
                     artwork.append(meta)
@@ -939,7 +943,7 @@ def get_artwork_files():
     else:
         logger.warning(f"Images directory not found or is not a directory: {IMAGES_DIR}")
 
-    logger.info(f"Found {len(artwork)} artwork files.")
+    logger.info(f"Found {len(artwork)} artwork files (filter={status_filter}).")
     return artwork
 
 
@@ -967,11 +971,13 @@ async def admin_home(
     _: None = Depends(_verify_admin),
 ) -> HTMLResponse:
     """Render the admin review dashboard."""
+    gallery_images = get_artwork_files(status_filter="approved")
     return templates.TemplateResponse(
         request,
         "reviewAddedFiles.html",
         {
             "pending_images": pending_images,
+            "gallery_images": gallery_images,
             "allowed_extensions": sorted(ALLOWED_IMAGE_EXTENSIONS),
         },
     )
@@ -984,11 +990,13 @@ async def review_added_files(
     _: None = Depends(_verify_admin),
 ) -> HTMLResponse:
     """Render the admin review dashboard. Alias for /admin."""
+    gallery_images = get_artwork_files(status_filter="approved")
     return templates.TemplateResponse(
         request,
         "reviewAddedFiles.html",
         {
             "pending_images": pending_images,
+            "gallery_images": gallery_images,
             "allowed_extensions": sorted(ALLOWED_IMAGE_EXTENSIONS),
         },
     )
@@ -999,8 +1007,9 @@ async def api_new_files(
     pending: List[Dict[str, Any]] = Depends(get_pending_files),
     _: None = Depends(_verify_admin),
 ) -> JSONResponse:
-    """Return the list of pending files as JSON."""
-    return JSONResponse({"pending": pending})
+    """Return pending and gallery files as JSON."""
+    gallery = get_artwork_files(status_filter="approved")
+    return JSONResponse({"pending": pending, "gallery": gallery})
 
 
 @app.get("/admin/config", response_class=JSONResponse)
@@ -1255,10 +1264,10 @@ async def update_image_metadata(
         "title": title.strip() or image_path.stem,
         "description": description.strip(),
     }
-    # Merge with existing sidecar and mark as reviewed
+    # Merge with existing sidecar and mark as approved
     existing = _load_metadata(image_path)
     existing.update(clean_metadata)
-    existing["reviewed"] = True
+    existing["status"] = "approved"
     _write_sidecar(image_path, existing)
 
     return RedirectResponse(
@@ -1266,6 +1275,37 @@ async def update_image_metadata(
         status_code=status.HTTP_303_SEE_OTHER,
     )
 
+
+@app.post("/admin/unapprove/{image_name}", response_class=JSONResponse)
+async def unapprove_image(
+    image_name: str,
+    _: None = Depends(_verify_admin),
+) -> JSONResponse:
+    """Move an approved image back to pending status."""
+    image_path = _resolve_image_path(image_name)
+    if not image_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+    _set_status_sidecar(image_path, "pending")
+    return JSONResponse({"status": "ok", "image": image_name, "new_status": "pending"})
+
+
+@app.post("/admin/delete/{image_name}", response_class=JSONResponse)
+async def soft_delete_image(
+    image_name: str,
+    _: None = Depends(_verify_admin),
+) -> JSONResponse:
+    """Soft-delete an image by moving it and its sidecar to .trash/."""
+    image_path = _resolve_image_path(image_name)
+    if not image_path.exists():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+    trash_dir = IMAGES_DIR / ".trash"
+    trash_dir.mkdir(exist_ok=True)
+    sidecar_path = image_path.with_suffix(".json")
+    shutil.move(str(image_path), str(trash_dir / image_path.name))
+    if sidecar_path.exists():
+        shutil.move(str(sidecar_path), str(trash_dir / sidecar_path.name))
+    logger.info("Soft-deleted %s to .trash/", image_name)
+    return JSONResponse({"status": "ok", "image": image_name, "action": "deleted"})
 
 
 @app.get("/artwork/{image_filename}", response_class=HTMLResponse)
@@ -1310,7 +1350,7 @@ async def read_root(request: Request):
     context = {
         "request": request, # Required by Jinja2Templates
         "artwork_files": artwork_list,
-        "gallery_title": "My Girlfriend's Artwork Gallery" # Customizable title
+        "gallery_title": GALLERY_TITLE
     }
 
     # Render the HTML template with the context data

--- a/main.py
+++ b/main.py
@@ -824,6 +824,14 @@ def _verify_admin(
             detail="Invalid credentials",
             headers={"WWW-Authenticate": 'Basic realm="Artwork Admin"'},
         )
+    if request.method in ("POST", "PUT", "PATCH", "DELETE"):
+        origin = request.headers.get("origin") or request.headers.get("referer", "")
+        host = request.headers.get("host", "")
+        if origin and host and host not in origin:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Cross-origin request rejected",
+            )
 
 
 
@@ -1310,9 +1318,14 @@ async def soft_delete_image(
     trash_dir = IMAGES_DIR / ".trash"
     trash_dir.mkdir(exist_ok=True)
     sidecar_path = image_path.with_suffix(".json")
-    shutil.move(str(image_path), str(trash_dir / image_path.name))
+    trash_name = image_path.name
+    if (trash_dir / trash_name).exists():
+        stem, suffix = image_path.stem, image_path.suffix
+        trash_name = f"{stem}_{int(time.time())}{suffix}"
+    shutil.move(str(image_path), str(trash_dir / trash_name))
     if sidecar_path.exists():
-        shutil.move(str(sidecar_path), str(trash_dir / sidecar_path.name))
+        trash_sidecar = Path(trash_name).with_suffix(".json").name
+        shutil.move(str(sidecar_path), str(trash_dir / trash_sidecar))
     logger.info("Soft-deleted %s to .trash/", image_name)
     return JSONResponse({"status": "ok", "image": image_name, "action": "deleted"})
 

--- a/manage_sidecars.py
+++ b/manage_sidecars.py
@@ -74,6 +74,7 @@ def _load_schema() -> Dict[str, Any]:
                         "raw_response": {"type": "object", "default": {}},
                     },
                 },
+                "status": {"type": "string", "enum": ["pending", "approved", "hidden"], "default": "pending"},
                 "reviewed": {"type": "boolean", "default": False},
                 "detected_at": {"type": "number", "default": 0},
             },
@@ -82,7 +83,7 @@ def _load_schema() -> Dict[str, Any]:
                 "description",
                 "ai_generated",
                 "ai_details",
-                "reviewed",
+                "status",
                 "detected_at",
             ],
             "additionalProperties": False,
@@ -90,6 +91,9 @@ def _load_schema() -> Dict[str, Any]:
 
 
 def _apply_schema_defaults(data: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
+    # Backwards-compat: convert reviewed → status before defaults fill it in
+    if "status" not in data and "reviewed" in data:
+        data["status"] = "approved" if data["reviewed"] else "pending"
     props = schema.get("properties", {})
     required = set(schema.get("required", []))
     for key in required:
@@ -107,13 +111,8 @@ def _apply_schema_defaults(data: Dict[str, Any], schema: Dict[str, Any]) -> Dict
                 data[key] = {}
             else:
                 data[key] = None
-    # Simple coercions
-    if isinstance(data.get("reviewed"), str):
-        lowered = data["reviewed"].strip().lower()
-        if lowered in {"true", "1", "yes", "y"}:
-            data["reviewed"] = True
-        elif lowered in {"false", "0", "no", "n"}:
-            data["reviewed"] = False
+    if "status" in data and data["status"] not in ("pending", "approved", "hidden"):
+        data["status"] = "pending"
     if isinstance(data.get("ai_generated"), str):
         lowered = data["ai_generated"].strip().lower()
         if lowered in {"true", "1", "yes", "y"}:
@@ -149,7 +148,7 @@ def _ensure_sidecar(image_path: Path, schema: Dict[str, Any]) -> None:
     sidecar.setdefault("ai_generated", False)
     if not isinstance(sidecar.get("ai_details"), dict):
         sidecar["ai_details"] = {}
-    sidecar.setdefault("reviewed", False)
+    sidecar.setdefault("status", "pending")
     sidecar.setdefault("detected_at", now)
     _atomic_write_json(json_path, sidecar)
 

--- a/manage_sidecars.py
+++ b/manage_sidecars.py
@@ -22,6 +22,15 @@ from typing import Any, Dict
 from jsonschema import validate as js_validate, ValidationError
 
 
+def _coerce_bool(value: Any) -> bool:
+    """Safely coerce a bool or string to a Python bool."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "y"}
+    return bool(value)
+
+
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = BASE_DIR / "Static"
 IMAGES_DIR = STATIC_DIR / "images"
@@ -93,7 +102,7 @@ def _load_schema() -> Dict[str, Any]:
 def _apply_schema_defaults(data: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
     # Backwards-compat: convert reviewed → status before defaults fill it in
     if "status" not in data and "reviewed" in data:
-        data["status"] = "approved" if data["reviewed"] else "pending"
+        data["status"] = "approved" if _coerce_bool(data["reviewed"]) else "pending"
     props = schema.get("properties", {})
     required = set(schema.get("required", []))
     for key in required:

--- a/scripts/migrate_status.py
+++ b/scripts/migrate_status.py
@@ -15,6 +15,14 @@ from pathlib import Path
 ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif"}
 
 
+def _coerce_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "y"}
+    return bool(value)
+
+
 def migrate(images_dir: Path, dry_run: bool = False) -> int:
     if not images_dir.is_dir():
         print(f"[error] Not a directory: {images_dir}")
@@ -41,14 +49,12 @@ def migrate(images_dir: Path, dry_run: bool = False) -> int:
             skipped += 1
             continue
 
-        reviewed = data.get("reviewed", False)
-        expected_status = "approved" if reviewed else "pending"
-
-        if data.get("status") == expected_status:
+        if "status" in data and data["status"] in ("pending", "approved", "hidden"):
             skipped += 1
             continue
 
-        data["status"] = expected_status
+        reviewed = _coerce_bool(data.get("reviewed", False))
+        data["status"] = "approved" if reviewed else "pending"
 
         if not dry_run:
             tmp = json_path.with_suffix(".json.tmp")

--- a/scripts/migrate_status.py
+++ b/scripts/migrate_status.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Migrate sidecar JSON files from reviewed (boolean) to status (enum).
+
+Usage:
+    python scripts/migrate_status.py [--images-dir Static/images]
+    python scripts/migrate_status.py --dry-run
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif"}
+
+
+def migrate(images_dir: Path, dry_run: bool = False) -> int:
+    if not images_dir.is_dir():
+        print(f"[error] Not a directory: {images_dir}")
+        return 1
+
+    migrated = 0
+    skipped = 0
+    total = 0
+
+    for name in sorted(os.listdir(images_dir)):
+        path = images_dir / name
+        if not (path.is_file() and path.suffix.lower() in ALLOWED_EXTENSIONS):
+            continue
+        total += 1
+        json_path = path.with_suffix(".json")
+        if not json_path.exists():
+            skipped += 1
+            continue
+
+        try:
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"[warn] {json_path.name}: {exc}")
+            skipped += 1
+            continue
+
+        reviewed = data.get("reviewed", False)
+        expected_status = "approved" if reviewed else "pending"
+
+        if data.get("status") == expected_status:
+            skipped += 1
+            continue
+
+        data["status"] = expected_status
+
+        if not dry_run:
+            tmp = json_path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            tmp.replace(json_path)
+
+        status_label = data["status"]
+        print(f"[migrated] {json_path.name}: reviewed={reviewed} → status={status_label}")
+        migrated += 1
+
+    print(f"\nTotal images: {total}, migrated: {migrated}, skipped: {skipped}")
+    if dry_run:
+        print("(dry run — no files changed)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Migrate sidecars from reviewed to status enum.")
+    parser.add_argument("--images-dir", type=Path, default=Path("Static/images"),
+                        help="Path to images directory (default: Static/images)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would be migrated without writing files")
+    args = parser.parse_args()
+    return migrate(args.images_dir, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
 </head>
-<body class="admin-page">
+<body class="admin-page" data-root-path="{{ request.scope.get('root_path', '') }}">
     <header>
         <h1>Administration</h1>
         <p class="admin-subheading">Gallery curation and artwork management</p>
@@ -21,11 +21,11 @@
     <div class="shader-bg"></div>
 
     <nav class="admin-tabs" role="tablist">
-        <button class="admin-tab active" role="tab" aria-selected="true" data-tab="dashboard">Dashboard</button>
-        <button class="admin-tab" role="tab" aria-selected="false" data-tab="settings">Settings</button>
+        <button class="admin-tab active" role="tab" id="btn-dashboard" aria-selected="true" aria-controls="tab-dashboard" data-tab="dashboard">Dashboard</button>
+        <button class="admin-tab" role="tab" id="btn-settings" aria-selected="false" aria-controls="tab-settings" data-tab="settings">Settings</button>
     </nav>
 
-    <div id="tab-dashboard" class="tab-content active">
+    <div id="tab-dashboard" class="tab-content active" role="tabpanel" aria-labelledby="btn-dashboard">
         <main class="admin-container">
             <!-- Upload Section -->
             <section class="admin-panel">
@@ -139,7 +139,7 @@
         </main>
     </div>
 
-    <div id="tab-settings" class="tab-content">
+    <div id="tab-settings" class="tab-content" role="tabpanel" aria-labelledby="btn-settings">
         <main class="admin-container">
             <section class="admin-panel">
                 <h2>AI Metadata Settings</h2>
@@ -202,6 +202,7 @@
     const forceOverwrite = document.getElementById('force-overwrite');
     const searchInput = document.getElementById('search-input');
     const resetConfigBtn = document.getElementById('reset-config');
+    const ROOT = document.body.dataset.rootPath || '';
 
     // Tab navigation
     document.querySelectorAll('.admin-tab').forEach(tab => {
@@ -294,7 +295,7 @@
         if (section === 'gallery') {
             const editLink = document.createElement('a');
             editLink.className = 'button secondary';
-            editLink.href = `/admin/review/${encodeURIComponent(item.name)}`;
+            editLink.href = `${ROOT}/admin/review/${encodeURIComponent(item.name)}`;
             editLink.textContent = 'Edit';
             actions.appendChild(editLink);
 
@@ -308,7 +309,7 @@
         } else {
             const reviewLink = document.createElement('a');
             reviewLink.className = 'button';
-            reviewLink.href = `/admin/review/${encodeURIComponent(item.name)}`;
+            reviewLink.href = `${ROOT}/admin/review/${encodeURIComponent(item.name)}`;
             reviewLink.textContent = 'Review';
             actions.appendChild(reviewLink);
         }
@@ -363,7 +364,7 @@
         if (action === 'delete' && !confirm(`Delete "${name}"? It will be moved to .trash/.`)) return;
 
         try {
-            const res = await fetch(`/admin/${action}/${encodeURIComponent(name)}`, { method: 'POST' });
+            const res = await fetch(`${ROOT}/admin/${action}/${encodeURIComponent(name)}`, { method: 'POST' });
             const data = await res.json();
             if (!res.ok) throw new Error(data.detail || `${action} failed`);
             showFeedback(`${name}: ${action}d successfully.`, 'success');
@@ -376,7 +377,7 @@
 
     async function loadConfig() {
         try {
-            const res = await fetch('/admin/config');
+            const res = await fetch(`${ROOT}/admin/config`);
             const data = await res.json();
             const cfg = data.ai || {};
             if (typeof cfg.enabled === 'boolean') aiEnabled.checked = cfg.enabled;
@@ -399,7 +400,7 @@
             }
         };
         try {
-            const res = await fetch('/admin/config', {
+            const res = await fetch(`${ROOT}/admin/config`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)
@@ -415,7 +416,7 @@
 
     resetConfigBtn?.addEventListener('click', async () => {
         try {
-            const res = await fetch('/admin/config/reset', { method: 'POST' });
+            const res = await fetch(`${ROOT}/admin/config/reset`, { method: 'POST' });
             if (!res.ok) throw new Error('Reset failed');
             showFeedback('Settings reset to defaults.', 'success');
             await loadConfig();
@@ -437,7 +438,7 @@
             return;
         }
         try {
-            const res = await fetch('/admin/ai/regenerate', {
+            const res = await fetch(`${ROOT}/admin/ai/regenerate`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ images: names, force: !!forceOverwrite?.checked })
@@ -461,7 +462,7 @@
         const formData = new FormData();
         Array.from(files).forEach(file => formData.append('files', file));
 
-        const response = await fetch('/admin/upload', { method: 'POST', body: formData });
+        const response = await fetch(`${ROOT}/admin/upload`, { method: 'POST', body: formData });
         const data = await response.json();
         if (!response.ok) throw new Error(data.detail || 'Upload failed');
         await fetchAll();
@@ -471,7 +472,7 @@
     }
 
     async function fetchAll(showMessage = false) {
-        const response = await fetch('/admin/api/new-files');
+        const response = await fetch(`${ROOT}/admin/api/new-files`);
         const data = await response.json();
         if (!response.ok) throw new Error(data.detail || 'Unable to refresh');
         renderPendingList(data.pending || []);
@@ -511,7 +512,7 @@
         e.preventDefault();
         const formData = new FormData(pathForm);
         try {
-            const response = await fetch('/admin/import-path', { method: 'POST', body: formData });
+            const response = await fetch(`${ROOT}/admin/import-path`, { method: 'POST', body: formData });
             const data = await response.json();
             if (!response.ok) throw new Error(data.detail || 'Import failed');
             await fetchAll();

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Artwork Admin Review</title>
+    <title>Artwork Admin</title>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
     <link href="https://api.fontshare.com/v2/css?f[]=clash-grotesk@200,300,400,500,600,700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -12,123 +12,168 @@
 <body class="admin-page">
     <header>
         <h1>Administration</h1>
-        <p class="admin-subheading">Upload, detect, and describe artifacts</p>
+        <p class="admin-subheading">Gallery curation and artwork management</p>
         <nav class="admin-nav">
             <a href="/" class="button secondary">View Public Gallery</a>
-            <button type="button" id="refresh-pending" class="button secondary">Refresh Pending List</button>
         </nav>
     </header>
 
     <div class="shader-bg"></div>
 
-    <main class="admin-container">
-        <section class="admin-panel">
-            <h2>AI Metadata Settings</h2>
-            <p class="panel-description">Control automatic title/description generation for new or unreviewed images.</p>
-            <form id="ai-config-form" class="ai-config-form">
-                <div class="form-row">
-                    <label class="checkbox">
-                        <input type="checkbox" id="ai-enabled">
-                        <span>Enable AI metadata generation</span>
-                    </label>
-                </div>
-                <div class="form-row">
-                    <label for="ai-model">Model</label>
-                    <select id="ai-model">
-                        <option value="gpt-4o-mini">gpt-4o-mini</option>
-                        <option value="gpt-5-mini">gpt-5-mini</option>
-                    </select>
-                </div>
-                <div class="form-row">
-                    <label for="ai-temp">Temperature</label>
-                    <input type="number" id="ai-temp" min="0" max="2" step="0.1" value="0.6">
-                </div>
-                <div class="form-row">
-                    <label for="ai-tokens">Max output tokens</label>
-                    <input type="number" id="ai-tokens" min="16" max="4000" step="1" value="600">
-                </div>
-                <div class="form-actions">
-                    <button type="submit" class="button">Save settings</button>
-                </div>
-            </form>
-        </section>
-        <section class="admin-panel">
-            <h2>Upload new artwork</h2>
-            <p class="panel-description">Drag and drop image files or click below to open a file browser. You can also include existing JSON sidecar files.</p>
-            <div id="dropzone" class="dropzone" role="button" tabindex="0" aria-label="Drop images here or press enter to choose files">
-                <svg aria-hidden="true" focusable="false" class="dropzone-icon" viewBox="0 0 24 24">
-                    <path d="M12 2a5 5 0 0 1 5 5h3a1 1 0 1 1 0 2h-3v2h1a4 4 0 1 1 0 8H7a5 5 0 0 1-1-9.9V9H3a1 1 0 1 1 0-2h3a5 5 0 0 1 6-5Zm0 2a3 3 0 0 0-3 3v2a1 1 0 0 1-1 1H7a3 3 0 1 0 0 6h11a2 2 0 1 0 0-4h-2a1 1 0 0 1-1-1V7a3 3 0 0 0-3-3Zm0 4a1 1 0 0 1 1 1v2.585l1.293-1.293a1 1 0 1 1 1.414 1.414l-3.004 3.003a1 1 0 0 1-1.414 0l-3.004-3.003a1 1 0 0 1 1.414-1.414L11 11.585V9a1 1 0 0 1 1-1Z" fill="currentColor"/>
-                </svg>
-                <p><strong>Drop files here</strong> or use the button below.</p>
-                <button type="button" id="select-files" class="button">Choose files</button>
-                <input type="file" id="file-input" name="files" accept="image/*,.json" multiple hidden>
-                <p class="supported-formats">Supported formats: {{ allowed_extensions | join(', ') }} and JSON sidecars.</p>
-            </div>
+    <nav class="admin-tabs" role="tablist">
+        <button class="admin-tab active" role="tab" aria-selected="true" data-tab="dashboard">Dashboard</button>
+        <button class="admin-tab" role="tab" aria-selected="false" data-tab="settings">Settings</button>
+    </nav>
 
-            <form id="path-form" class="path-form">
-                <h3>Import from server path</h3>
-                <p class="panel-description">Paste an absolute file or directory path that the server can read. Images will be copied into <code>Static/images</code>.</p>
-                <label for="path-input" class="sr-only">Absolute path on the server</label>
-                <div class="path-input-row">
-                    <input type="text" id="path-input" name="path" placeholder="/home/user/photos" required>
-                    <button type="submit" class="button">Import</button>
+    <div id="tab-dashboard" class="tab-content active">
+        <main class="admin-container">
+            <!-- Upload Section -->
+            <section class="admin-panel">
+                <h2>Upload new artwork</h2>
+                <p class="panel-description">Drag and drop image files or click below to open a file browser.</p>
+                <div id="dropzone" class="dropzone" role="button" tabindex="0" aria-label="Drop images here or press enter to choose files">
+                    <svg aria-hidden="true" focusable="false" class="dropzone-icon" viewBox="0 0 24 24">
+                        <path d="M12 2a5 5 0 0 1 5 5h3a1 1 0 1 1 0 2h-3v2h1a4 4 0 1 1 0 8H7a5 5 0 0 1-1-9.9V9H3a1 1 0 1 1 0-2h3a5 5 0 0 1 6-5Zm0 2a3 3 0 0 0-3 3v2a1 1 0 0 1-1 1H7a3 3 0 1 0 0 6h11a2 2 0 1 0 0-4h-2a1 1 0 0 1-1-1V7a3 3 0 0 0-3-3Zm0 4a1 1 0 0 1 1 1v2.585l1.293-1.293a1 1 0 1 1 1.414 1.414l-3.004 3.003a1 1 0 0 1-1.414 0l-3.004-3.003a1 1 0 0 1 1.414-1.414L11 11.585V9a1 1 0 0 1 1-1Z" fill="currentColor"/>
+                    </svg>
+                    <p><strong>Drop files here</strong> or use the button below.</p>
+                    <button type="button" id="select-files" class="button">Choose files</button>
+                    <input type="file" id="file-input" name="files" accept="image/*,.json" multiple hidden>
+                    <p class="supported-formats">Supported formats: {{ allowed_extensions | join(', ') }} and JSON sidecars.</p>
                 </div>
-            </form>
-        </section>
 
-        <section class="admin-panel">
-            <div class="panel-header">
-                <h2>Pending review <span id="pending-count" class="badge">{{ pending_images | length }}</span></h2>
-                <p class="panel-description">Review each image to confirm or edit the metadata that appears to visitors.</p>
-                <div class="panel-actions">
-                    <label class="checkbox" title="Overwrite existing title/description when regenerating">
-                        <input type="checkbox" id="force-overwrite">
-                        <span>Force overwrite</span>
-                    </label>
-                    <button type="button" id="select-all" class="button secondary">Select all</button>
-                    <button type="button" id="regen-selected" class="button">Re-run AI for selected</button>
+                <form id="path-form" class="path-form">
+                    <h3>Import from server path</h3>
+                    <p class="panel-description">Paste an absolute file or directory path that the server can read.</p>
+                    <label for="path-input" class="sr-only">Absolute path on the server</label>
+                    <div class="path-input-row">
+                        <input type="text" id="path-input" name="path" placeholder="/home/user/photos" required>
+                        <button type="submit" class="button">Import</button>
+                    </div>
+                </form>
+            </section>
+
+            <!-- Search Section -->
+            <section class="admin-panel">
+                <h2>Search</h2>
+                <div class="admin-search">
+                    <input type="text" id="search-input" placeholder="Filter by title or filename..." aria-label="Search artwork">
                 </div>
-            </div>
-            <div id="pending-list" class="pending-list" aria-live="polite">
-                {% if pending_images %}
-                    {% for item in pending_images %}
-                        <article class="pending-card" data-image-name="{{ item.name }}">
+            </section>
+
+            <!-- Gallery (Approved) Section -->
+            <section class="admin-panel">
+                <div class="panel-header">
+                    <h2>Gallery <span id="gallery-count" class="badge">{{ gallery_images | length }}</span></h2>
+                    <p class="panel-description">Approved artwork visible to the public.</p>
+                </div>
+                <div id="gallery-list" class="admin-grid" aria-live="polite">
+                    {% if gallery_images %}
+                        {% for item in gallery_images %}
+                        <article class="admin-card" data-image-name="{{ item.name }}" data-title="{{ item.title|default('', true) }}" data-section="gallery">
+                            <img src="{{ item.url }}" alt="{{ item.title or item.name }}" loading="lazy">
+                            <div class="admin-card-info">
+                                <h3>{{ item.title or item.name }}</h3>
+                                <p class="filename">{{ item.name }}</p>
+                                <div class="admin-card-actions">
+                                    <a class="button secondary" href="{{ url_for('preview_image_metadata', image_name=item.name) }}">Edit</a>
+                                    <button type="button" class="button secondary" data-action="unapprove" data-name="{{ item.name }}">Unapprove</button>
+                                    <button type="button" class="button danger" data-action="delete" data-name="{{ item.name }}">Delete</button>
+                                </div>
+                            </div>
+                        </article>
+                        {% endfor %}
+                    {% else %}
+                        <p class="empty-state">No approved artwork yet. Review pending items to add them to the gallery.</p>
+                    {% endif %}
+                </div>
+            </section>
+
+            <!-- Pending Section -->
+            <section class="admin-panel">
+                <div class="panel-header">
+                    <h2>Pending review <span id="pending-count" class="badge">{{ pending_images | length }}</span></h2>
+                    <p class="panel-description">Review each image to confirm or edit the metadata before publishing.</p>
+                    <div class="panel-actions">
+                        <label class="checkbox" title="Overwrite existing title/description when regenerating">
+                            <input type="checkbox" id="force-overwrite">
+                            <span>Force overwrite</span>
+                        </label>
+                        <button type="button" id="select-all" class="button secondary">Select all</button>
+                        <button type="button" id="regen-selected" class="button">Re-run AI for selected</button>
+                        <button type="button" id="refresh-pending" class="button secondary">Refresh</button>
+                    </div>
+                </div>
+                <div id="pending-list" class="admin-grid" aria-live="polite">
+                    {% if pending_images %}
+                        {% for item in pending_images %}
+                        <article class="admin-card" data-image-name="{{ item.name }}" data-title="{{ item.metadata.title|default('', true) }}" data-section="pending">
                             <div class="select-col">
                                 <input type="checkbox" class="item-select" aria-label="Select {{ item.name }}">
                             </div>
-                            <div class="pending-thumb">
-                                <img src="{{ item.url }}" alt="Preview of {{ item.metadata.title }}" loading="lazy">
-                            </div>
-                            <div class="pending-info">
-                                <h3>{{ item.metadata.title }}</h3>
+                            <img src="{{ item.url }}" alt="Preview of {{ item.metadata.title }}" loading="lazy">
+                            <div class="admin-card-info">
+                                <h3>{{ item.metadata.title or item.name }}</h3>
                                 <p class="filename">{{ item.name }}</p>
                                 {% if item.metadata.description %}
-                                    <p class="description">{{ item.metadata.description }}</p>
-                                {% else %}
-                                    <p class="description empty">No description detected yet.</p>
+                                    <p class="description">{{ item.metadata.description|truncate(80) }}</p>
                                 {% endif %}
-                                {% set ai = item.metadata.get('ai_details') or {} %}
-                                {% set ai_time = ai.get('created') or ai.get('attempted_at') or item.metadata.get('detected_at') %}
                                 <p class="ai-status">
                                     {% if item.metadata.get('ai_generated') %}
                                         <span class="badge">AI generated</span>
                                     {% else %}
                                         <span class="badge secondary">AI pending</span>
                                     {% endif %}
-                                    {% if ai_time %}
-                                        <span class="timestamp" data-ts="{{ ai_time }}"></span>
-                                    {% endif %}
                                 </p>
-                                <a class="button" href="{{ url_for('preview_image_metadata', image_name=item.name) }}">Review details</a>
+                                <div class="admin-card-actions">
+                                    <a class="button" href="{{ url_for('preview_image_metadata', image_name=item.name) }}">Review</a>
+                                    <button type="button" class="button danger" data-action="delete" data-name="{{ item.name }}">Delete</button>
+                                </div>
                             </div>
                         </article>
-                    {% endfor %}
-                {% else %}
-                    <p class="empty-state">No new files waiting for review. Upload artwork to begin curating descriptions.</p>
-                {% endif %}
-            </div>
-        </section>
-    </main>
+                        {% endfor %}
+                    {% else %}
+                        <p class="empty-state">No new files waiting for review.</p>
+                    {% endif %}
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <div id="tab-settings" class="tab-content">
+        <main class="admin-container">
+            <section class="admin-panel">
+                <h2>AI Metadata Settings</h2>
+                <p class="panel-description">Control automatic title/description generation for new images.</p>
+                <form id="ai-config-form" class="ai-config-form">
+                    <div class="form-row">
+                        <label class="checkbox">
+                            <input type="checkbox" id="ai-enabled">
+                            <span>Enable AI metadata generation</span>
+                        </label>
+                    </div>
+                    <div class="form-row">
+                        <label for="ai-model">Model</label>
+                        <select id="ai-model">
+                            <option value="gpt-4o-mini">gpt-4o-mini</option>
+                            <option value="gpt-5-mini">gpt-5-mini</option>
+                        </select>
+                    </div>
+                    <div class="form-row">
+                        <label for="ai-temp">Temperature</label>
+                        <input type="number" id="ai-temp" min="0" max="2" step="0.1" value="0.6">
+                    </div>
+                    <div class="form-row">
+                        <label for="ai-tokens">Max output tokens</label>
+                        <input type="number" id="ai-tokens" min="16" max="4000" step="1" value="600">
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="button">Save settings</button>
+                        <button type="button" id="reset-config" class="button secondary">Reset to defaults</button>
+                    </div>
+                </form>
+            </section>
+        </main>
+    </div>
 
     <section id="feedback" class="feedback" role="status" aria-live="polite" hidden></section>
 
@@ -143,6 +188,8 @@
     const feedback = document.getElementById('feedback');
     const pendingList = document.getElementById('pending-list');
     const pendingCount = document.getElementById('pending-count');
+    const galleryList = document.getElementById('gallery-list');
+    const galleryCount = document.getElementById('gallery-count');
     const refreshButton = document.getElementById('refresh-pending');
     const pathForm = document.getElementById('path-form');
     const aiForm = document.getElementById('ai-config-form');
@@ -153,102 +200,179 @@
     const selectAllBtn = document.getElementById('select-all');
     const regenBtn = document.getElementById('regen-selected');
     const forceOverwrite = document.getElementById('force-overwrite');
+    const searchInput = document.getElementById('search-input');
+    const resetConfigBtn = document.getElementById('reset-config');
+
+    // Tab navigation
+    document.querySelectorAll('.admin-tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+            document.querySelectorAll('.admin-tab').forEach(t => {
+                t.classList.remove('active');
+                t.setAttribute('aria-selected', 'false');
+            });
+            document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+            tab.classList.add('active');
+            tab.setAttribute('aria-selected', 'true');
+            document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+        });
+    });
+
+    // Search filtering
+    searchInput?.addEventListener('input', () => {
+        const query = searchInput.value.toLowerCase().trim();
+        document.querySelectorAll('.admin-card').forEach(card => {
+            const title = (card.dataset.title || '').toLowerCase();
+            const name = (card.dataset.imageName || '').toLowerCase();
+            card.style.display = (!query || title.includes(query) || name.includes(query)) ? '' : 'none';
+        });
+    });
 
     function showFeedback(message, type = 'info') {
         feedback.textContent = message;
         feedback.classList.remove('error', 'success');
         feedback.classList.add(type === 'error' ? 'error' : 'success');
         feedback.hidden = false;
-        window.setTimeout(() => {
-            feedback.hidden = true;
-        }, 8000);
+        window.setTimeout(() => { feedback.hidden = true; }, 8000);
     }
 
-    function renderPendingList(pending) {
-        pendingList.innerHTML = '';
-        if (!pending || pending.length === 0) {
-            const emptyMessage = document.createElement('p');
-            emptyMessage.className = 'empty-state';
-            emptyMessage.textContent = 'No new files waiting for review. Upload artwork to begin curating descriptions.';
-            pendingList.appendChild(emptyMessage);
+    function renderCard(item, section) {
+        const card = document.createElement('article');
+        card.className = 'admin-card';
+        card.dataset.imageName = item.name;
+        card.dataset.title = item.metadata?.title || item.title || '';
+        card.dataset.section = section;
+
+        if (section === 'pending') {
+            const selectCol = document.createElement('div');
+            selectCol.className = 'select-col';
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.className = 'item-select';
+            checkbox.setAttribute('aria-label', `Select ${item.name}`);
+            selectCol.appendChild(checkbox);
+            card.appendChild(selectCol);
+        }
+
+        const img = document.createElement('img');
+        img.src = item.url;
+        img.alt = item.metadata?.title || item.title || item.name;
+        img.loading = 'lazy';
+        card.appendChild(img);
+
+        const info = document.createElement('div');
+        info.className = 'admin-card-info';
+
+        const title = document.createElement('h3');
+        title.textContent = item.metadata?.title || item.title || item.name;
+        info.appendChild(title);
+
+        const filename = document.createElement('p');
+        filename.className = 'filename';
+        filename.textContent = item.name;
+        info.appendChild(filename);
+
+        if (section === 'pending') {
+            const desc = item.metadata?.description;
+            if (desc) {
+                const descEl = document.createElement('p');
+                descEl.className = 'description';
+                descEl.textContent = desc.length > 80 ? desc.substring(0, 80) + '...' : desc;
+                info.appendChild(descEl);
+            }
+            const aiStatus = document.createElement('p');
+            aiStatus.className = 'ai-status';
+            const badge = document.createElement('span');
+            badge.className = item.metadata?.ai_generated ? 'badge' : 'badge secondary';
+            badge.textContent = item.metadata?.ai_generated ? 'AI generated' : 'AI pending';
+            aiStatus.appendChild(badge);
+            info.appendChild(aiStatus);
+        }
+
+        const actions = document.createElement('div');
+        actions.className = 'admin-card-actions';
+
+        if (section === 'gallery') {
+            const editLink = document.createElement('a');
+            editLink.className = 'button secondary';
+            editLink.href = `/admin/review/${encodeURIComponent(item.name)}`;
+            editLink.textContent = 'Edit';
+            actions.appendChild(editLink);
+
+            const unapproveBtn = document.createElement('button');
+            unapproveBtn.type = 'button';
+            unapproveBtn.className = 'button secondary';
+            unapproveBtn.dataset.action = 'unapprove';
+            unapproveBtn.dataset.name = item.name;
+            unapproveBtn.textContent = 'Unapprove';
+            actions.appendChild(unapproveBtn);
         } else {
-            pending.forEach((item) => {
-                const card = document.createElement('article');
-                card.className = 'pending-card';
-                card.dataset.imageName = item.name;
-
-                const selectCol = document.createElement('div');
-                selectCol.className = 'select-col';
-                const checkbox = document.createElement('input');
-                checkbox.type = 'checkbox';
-                checkbox.className = 'item-select';
-                checkbox.setAttribute('aria-label', `Select ${item.name}`);
-                selectCol.appendChild(checkbox);
-                card.appendChild(selectCol);
-
-                const thumb = document.createElement('div');
-                thumb.className = 'pending-thumb';
-                const img = document.createElement('img');
-                img.src = item.url;
-                img.alt = `Preview of ${item.metadata?.title || item.name}`;
-                img.loading = 'lazy';
-                thumb.appendChild(img);
-                card.appendChild(thumb);
-
-                const info = document.createElement('div');
-                info.className = 'pending-info';
-
-                const title = document.createElement('h3');
-                title.textContent = item.metadata?.title || item.name;
-                info.appendChild(title);
-
-                const filename = document.createElement('p');
-                filename.className = 'filename';
-                filename.textContent = item.name;
-                info.appendChild(filename);
-
-                const description = document.createElement('p');
-                description.className = 'description';
-                const desc = item.metadata?.description;
-                if (desc) {
-                    description.textContent = desc;
-                } else {
-                    description.classList.add('empty');
-                    description.textContent = 'No description detected yet.';
-                }
-                info.appendChild(description);
-
-                const ai = item.metadata?.ai_details || {};
-                const aiStatus = document.createElement('p');
-                aiStatus.className = 'ai-status';
-                const badge = document.createElement('span');
-                const generated = !!item.metadata?.ai_generated;
-                badge.className = generated ? 'badge' : 'badge secondary';
-                badge.textContent = generated ? 'AI generated' : 'AI pending';
-                aiStatus.appendChild(badge);
-                const ts = ai.created || ai.attempted_at || item.metadata?.detected_at;
-                if (ts) {
-                    const tsSpan = document.createElement('span');
-                    tsSpan.className = 'timestamp';
-                    tsSpan.textContent = ' · ' + new Date(ts * 1000).toLocaleString();
-                    aiStatus.appendChild(tsSpan);
-                }
-                info.appendChild(aiStatus);
-
-                const link = document.createElement('a');
-                link.className = 'button';
-                link.href = `/admin/review/${encodeURIComponent(item.name)}`;
-                link.textContent = 'Review details';
-                info.appendChild(link);
-
-                card.appendChild(info);
-                pendingList.appendChild(card);
-            });
+            const reviewLink = document.createElement('a');
+            reviewLink.className = 'button';
+            reviewLink.href = `/admin/review/${encodeURIComponent(item.name)}`;
+            reviewLink.textContent = 'Review';
+            actions.appendChild(reviewLink);
         }
-        if (pendingCount) {
-            pendingCount.textContent = pending ? pending.length : 0;
-        }
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.type = 'button';
+        deleteBtn.className = 'button danger';
+        deleteBtn.dataset.action = 'delete';
+        deleteBtn.dataset.name = item.name;
+        deleteBtn.textContent = 'Delete';
+        actions.appendChild(deleteBtn);
+
+        info.appendChild(actions);
+        card.appendChild(info);
+        return card;
     }
+
+    function renderGalleryList(items) {
+        galleryList.innerHTML = '';
+        if (!items || items.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'empty-state';
+            empty.textContent = 'No approved artwork yet.';
+            galleryList.appendChild(empty);
+        } else {
+            items.forEach(item => galleryList.appendChild(renderCard(item, 'gallery')));
+        }
+        if (galleryCount) galleryCount.textContent = items ? items.length : 0;
+    }
+
+    function renderPendingList(items) {
+        pendingList.innerHTML = '';
+        if (!items || items.length === 0) {
+            const empty = document.createElement('p');
+            empty.className = 'empty-state';
+            empty.textContent = 'No new files waiting for review.';
+            pendingList.appendChild(empty);
+        } else {
+            items.forEach(item => pendingList.appendChild(renderCard(item, 'pending')));
+        }
+        if (pendingCount) pendingCount.textContent = items ? items.length : 0;
+    }
+
+    // Action handlers (unapprove, delete) via event delegation
+    document.addEventListener('click', async (e) => {
+        const btn = e.target.closest('[data-action]');
+        if (!btn) return;
+        const action = btn.dataset.action;
+        const name = btn.dataset.name;
+        if (!name) return;
+
+        if (action === 'delete' && !confirm(`Delete "${name}"? It will be moved to .trash/.`)) return;
+
+        try {
+            const res = await fetch(`/admin/${action}/${encodeURIComponent(name)}`, { method: 'POST' });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.detail || `${action} failed`);
+            showFeedback(`${name}: ${action}d successfully.`, 'success');
+            await fetchAll();
+        } catch (err) {
+            console.error(err);
+            showFeedback(err.message, 'error');
+        }
+    });
 
     async function loadConfig() {
         try {
@@ -289,9 +413,20 @@
         }
     }
 
+    resetConfigBtn?.addEventListener('click', async () => {
+        try {
+            const res = await fetch('/admin/config/reset', { method: 'POST' });
+            if (!res.ok) throw new Error('Reset failed');
+            showFeedback('Settings reset to defaults.', 'success');
+            await loadConfig();
+        } catch (e) {
+            showFeedback(e.message, 'error');
+        }
+    });
+
     function selectedNames() {
-        return Array.from(document.querySelectorAll('.pending-card .item-select:checked'))
-            .map((cb) => cb.closest('.pending-card')?.dataset.imageName)
+        return Array.from(document.querySelectorAll('.admin-card .item-select:checked'))
+            .map(cb => cb.closest('.admin-card')?.dataset.imageName)
             .filter(Boolean);
     }
 
@@ -322,146 +457,93 @@
     }
 
     async function uploadFiles(files) {
-        if (!files || files.length === 0) {
-            return;
-        }
+        if (!files || files.length === 0) return;
         const formData = new FormData();
-        Array.from(files).forEach((file) => formData.append('files', file));
+        Array.from(files).forEach(file => formData.append('files', file));
 
-        const response = await fetch('/admin/upload', {
-            method: 'POST',
-            body: formData,
-        });
+        const response = await fetch('/admin/upload', { method: 'POST', body: formData });
         const data = await response.json();
-        if (!response.ok) {
-            throw new Error(data.detail || 'Upload failed');
-        }
-        renderPendingList(data.pending || []);
+        if (!response.ok) throw new Error(data.detail || 'Upload failed');
+        await fetchAll();
         const saved = data.saved?.length ? `Saved: ${data.saved.join(', ')}` : '';
         const skipped = data.skipped?.length ? ` Skipped: ${data.skipped.join(', ')}` : '';
         showFeedback(`${data.message || 'Upload complete.'} ${saved}${skipped}`.trim(), 'success');
     }
 
-    async function fetchPending(showMessage = false) {
+    async function fetchAll(showMessage = false) {
         const response = await fetch('/admin/api/new-files');
         const data = await response.json();
-        if (!response.ok) {
-            throw new Error(data.detail || 'Unable to refresh pending files');
-        }
+        if (!response.ok) throw new Error(data.detail || 'Unable to refresh');
         renderPendingList(data.pending || []);
-        if (showMessage) {
-            showFeedback('Pending list refreshed.', 'success');
-        }
+        renderGalleryList(data.gallery || []);
+        if (showMessage) showFeedback('Refreshed.', 'success');
     }
 
     if (dropzone) {
-        ['dragenter', 'dragover'].forEach((eventName) => {
-            dropzone.addEventListener(eventName, (event) => {
-                event.preventDefault();
-                event.stopPropagation();
+        ['dragenter', 'dragover'].forEach(ev => {
+            dropzone.addEventListener(ev, e => {
+                e.preventDefault(); e.stopPropagation();
                 dropzone.classList.add('is-dragover');
             });
         });
-
-        ['dragleave', 'dragend', 'drop'].forEach((eventName) => {
-            dropzone.addEventListener(eventName, (event) => {
-                event.preventDefault();
-                event.stopPropagation();
+        ['dragleave', 'dragend', 'drop'].forEach(ev => {
+            dropzone.addEventListener(ev, e => {
+                e.preventDefault(); e.stopPropagation();
                 dropzone.classList.remove('is-dragover');
             });
         });
-
-        dropzone.addEventListener('drop', async (event) => {
-            try {
-                await uploadFiles(event.dataTransfer.files);
-            } catch (error) {
-                console.error(error);
-                showFeedback(error.message, 'error');
-            }
+        dropzone.addEventListener('drop', async e => {
+            try { await uploadFiles(e.dataTransfer.files); }
+            catch (err) { console.error(err); showFeedback(err.message, 'error'); }
         });
-
-        dropzone.addEventListener('keydown', (event) => {
-            if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                fileInput?.click();
-            }
+        dropzone.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); fileInput?.click(); }
         });
     }
 
     selectFilesButton?.addEventListener('click', () => fileInput?.click());
-
-    fileInput?.addEventListener('change', async (event) => {
-        try {
-            await uploadFiles(event.target.files);
-            event.target.value = '';
-        } catch (error) {
-            console.error(error);
-            showFeedback(error.message, 'error');
-        }
+    fileInput?.addEventListener('change', async e => {
+        try { await uploadFiles(e.target.files); e.target.value = ''; }
+        catch (err) { console.error(err); showFeedback(err.message, 'error'); }
     });
 
-    pathForm?.addEventListener('submit', async (event) => {
-        event.preventDefault();
+    pathForm?.addEventListener('submit', async e => {
+        e.preventDefault();
         const formData = new FormData(pathForm);
         try {
-            const response = await fetch('/admin/import-path', {
-                method: 'POST',
-                body: formData,
-            });
+            const response = await fetch('/admin/import-path', { method: 'POST', body: formData });
             const data = await response.json();
-            if (!response.ok) {
-                throw new Error(data.detail || 'Import failed');
-            }
-            renderPendingList(data.pending || []);
+            if (!response.ok) throw new Error(data.detail || 'Import failed');
+            await fetchAll();
             const copied = data.copied?.length ? `Imported: ${data.copied.join(', ')}` : '';
             const skipped = data.skipped?.length ? ` Skipped: ${data.skipped.join(', ')}` : '';
             showFeedback(`${copied}${skipped}`.trim() || 'Import complete.', 'success');
             pathForm.reset();
-        } catch (error) {
-            console.error(error);
-            showFeedback(error.message, 'error');
+        } catch (err) {
+            console.error(err);
+            showFeedback(err.message, 'error');
         }
     });
 
     aiForm?.addEventListener('submit', saveConfig);
     selectAllBtn?.addEventListener('click', () => {
-        const boxes = document.querySelectorAll('.pending-card .item-select');
+        const boxes = document.querySelectorAll('.admin-card[data-section="pending"] .item-select');
         const allChecked = Array.from(boxes).every(cb => cb.checked);
         boxes.forEach(cb => cb.checked = !allChecked);
     });
     regenBtn?.addEventListener('click', regenSelected);
 
     refreshButton?.addEventListener('click', async () => {
-        try {
-            await fetchPending(true);
-        } catch (error) {
-            console.error(error);
-            showFeedback(error.message, 'error');
-        }
+        try { await fetchAll(true); }
+        catch (err) { console.error(err); showFeedback(err.message, 'error'); }
     });
 
     window.setInterval(async () => {
-        try {
-            await fetchPending(false);
-        } catch (error) {
-            console.error(error);
-        }
+        try { await fetchAll(false); }
+        catch (err) { console.error(err); }
     }, 15000);
 
-    // Initial load
     loadConfig();
-
-    // Format any server-rendered timestamps
-    function formatServerTimestamps() {
-        document.querySelectorAll('.ai-status .timestamp[data-ts]')
-            .forEach((el) => {
-                const ts = parseFloat(el.getAttribute('data-ts'));
-                if (!isNaN(ts)) {
-                    el.textContent = ' · ' + new Date(ts * 1000).toLocaleString();
-                }
-            });
-    }
-    formatServerTimestamps();
     </script>
 </body>
 </html>

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -14,7 +14,7 @@
         <h1>Administration</h1>
         <p class="admin-subheading">Gallery curation and artwork management</p>
         <nav class="admin-nav">
-            <a href="/" class="button secondary">View Public Gallery</a>
+            <a href="{{ url_for('read_root') }}" class="button secondary">View Public Gallery</a>
         </nav>
     </header>
 
@@ -43,10 +43,10 @@
 
                 <form id="path-form" class="path-form">
                     <h3>Import from server path</h3>
-                    <p class="panel-description">Paste an absolute file or directory path that the server can read.</p>
-                    <label for="path-input" class="sr-only">Absolute path on the server</label>
+                    <p class="panel-description">Enter a path relative to the server's import directory.</p>
+                    <label for="path-input" class="sr-only">Path relative to import directory</label>
                     <div class="path-input-row">
-                        <input type="text" id="path-input" name="path" placeholder="/home/user/photos" required>
+                        <input type="text" id="path-input" name="path" placeholder="photos/batch-1" required>
                         <button type="submit" class="button">Import</button>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary
- **Schema migration**: Replace `reviewed` boolean with `status` enum (`pending`/`approved`/`hidden`) in `ImageSidecar.schema.json`, `main.py`, and `manage_sidecars.py` with backwards-compatible on-read conversion
- **Public gallery filter**: `get_artwork_files()` now only shows `status: "approved"` images on the public gallery — 10 approved, 174 pending after migration
- **Admin page overhaul**: Full-width card grid layout, tab navigation (Dashboard/Settings), search bar filtering by title/filename, Gallery section with curation actions (edit, unapprove, soft-delete), separate Pending section
- **New endpoints**: `POST /admin/unapprove/{image_name}` (move back to pending), `POST /admin/delete/{image_name}` (soft-delete to `.trash/`)
- **Gallery title**: Configurable via `GALLERY_TITLE` env var (default: "Artazzen Gallery")
- **Migration script**: `scripts/migrate_status.py` for bulk-converting existing sidecars
- **Watcher fix**: `FileNotFoundError` handling in background directory watcher

## Test plan
- [x] All 21 existing pytest tests pass
- [x] Public gallery shows only approved images (10/184)
- [x] Admin page loads with correct gallery and pending counts
- [x] API endpoint `/admin/api/new-files` returns both `pending` and `gallery` arrays
- [x] Unapprove endpoint returns 404 for nonexistent images
- [x] Settings tab renders with AI config form
- [ ] Manual: verify card grid layout in browser
- [ ] Manual: test search filtering
- [ ] Manual: test unapprove and soft-delete actions
- [ ] Manual: verify `.trash/` directory is created on delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147Vq9oNTpzMzmNPEeySZd3
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

