### PR TITLE
feat: schema v2, mobile web, dark mode, SwiftUI spec

### DIFF
--- a/ArtazzenMobile/Package.swift
+++ b/ArtazzenMobile/Package.swift
@@ -5,10 +5,10 @@ let package = Package(
     name: "ArtazzenMobile",
     platforms: [.iOS(.v17)],
     products: [
-        .library(name: "ArtazzenMobile", targets: ["ArtazzenMobile"]),
+        .executable(name: "ArtazzenMobile", targets: ["ArtazzenMobile"]),
     ],
     targets: [
-        .target(name: "ArtazzenMobile", path: "Sources"),
+        .executableTarget(name: "ArtazzenMobile", path: "Sources"),
         .testTarget(name: "ArtazzenMobileTests", dependencies: ["ArtazzenMobile"], path: "Tests/ArtazzenMobileTests"),
     ]
 )

--- a/ArtazzenMobile/Package.swift
+++ b/ArtazzenMobile/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ArtazzenMobile",
+    platforms: [.iOS(.v17)],
+    products: [
+        .library(name: "ArtazzenMobile", targets: ["ArtazzenMobile"]),
+    ],
+    targets: [
+        .target(name: "ArtazzenMobile", path: "Sources"),
+        .testTarget(name: "ArtazzenMobileTests", dependencies: ["ArtazzenMobile"], path: "Tests/ArtazzenMobileTests"),
+    ]
+)

--- a/ArtazzenMobile/Sources/ArtazzenMobileApp.swift
+++ b/ArtazzenMobile/Sources/ArtazzenMobileApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ArtazzenMobileApp: App {
+    var body: some Scene {
+        WindowGroup {
+            MainTabView()
+        }
+    }
+}

--- a/ArtazzenMobile/Sources/Components/AIFieldEditor.swift
+++ b/ArtazzenMobile/Sources/Components/AIFieldEditor.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct AIFieldRow<Content: View>: View {
+    let label: String
+    let field: Artwork.AIField
+    @Binding var artwork: Artwork
+    @ViewBuilder var content: () -> Content
+
+    @State private var isRegenerating = false
+
+    private var isAIGenerated: Bool {
+        artwork.aiFields.contains(field)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                    .font(.azMono)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if isAIGenerated {
+                    Text("AI")
+                        .font(.system(size: 9, weight: .bold, design: .monospaced))
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(Color.azViolet.opacity(0.15))
+                        .foregroundStyle(Color.azViolet)
+                        .clipShape(RoundedRectangle(cornerRadius: 2))
+                }
+                Button {
+                    isRegenerating = true
+                    // Call ArtazzenAPI.regenerateFields
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                        isRegenerating = false
+                    }
+                } label: {
+                    if isRegenerating {
+                        ProgressView()
+                            .controlSize(.mini)
+                    } else {
+                        Image(systemName: "sparkles")
+                            .font(.caption)
+                    }
+                }
+                .buttonStyle(.borderless)
+                .tint(Color.azViolet)
+            }
+            content()
+        }
+    }
+}

--- a/ArtazzenMobile/Sources/Components/ArtworkCard.swift
+++ b/ArtazzenMobile/Sources/Components/ArtworkCard.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct ArtworkCard: View {
+    let artwork: Artwork
+    var showStatus = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            AsyncImage(url: artwork.imageURL) { image in
+                image.resizable().aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Rectangle().fill(Color.azCarbon.opacity(0.1))
+            }
+            .frame(height: 200)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .overlay(alignment: .topTrailing) {
+                if showStatus {
+                    StatusBadge(status: artwork.status)
+                        .padding(6)
+                }
+            }
+
+            Text(artwork.title)
+                .font(.azBody)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+
+            if !artwork.caption.isEmpty {
+                Text(artwork.caption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            if !artwork.tags.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(artwork.tags.prefix(3), id: \.self) { tag in
+                        TagPill(text: tag)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.azParchment.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.azCarbon.opacity(0.1), lineWidth: 1))
+    }
+}

--- a/ArtazzenMobile/Sources/Components/StatusBadge.swift
+++ b/ArtazzenMobile/Sources/Components/StatusBadge.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct StatusBadge: View {
+    let status: Artwork.ArtworkStatus
+
+    private var color: Color {
+        switch status {
+        case .approved: .azTeal
+        case .pending: .azOrange
+        case .hidden: .azCarbon.opacity(0.5)
+        }
+    }
+
+    var body: some View {
+        Text(status.rawValue.uppercased())
+            .font(.system(size: 10, weight: .bold, design: .monospaced))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+}

--- a/ArtazzenMobile/Sources/Components/TagPill.swift
+++ b/ArtazzenMobile/Sources/Components/TagPill.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct TagPill: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.azMono)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(Color.azCarbon.opacity(0.05))
+            .clipShape(Capsule())
+            .overlay(Capsule().stroke(Color.azCarbon.opacity(0.1), lineWidth: 1))
+    }
+}

--- a/ArtazzenMobile/Sources/Models/AIConfig.swift
+++ b/ArtazzenMobile/Sources/Models/AIConfig.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct AIConfig: Codable {
+    var enabled: Bool
+    var model: String
+    var temperature: Double
+    var maxOutputTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case enabled, model, temperature
+        case maxOutputTokens = "max_output_tokens"
+    }
+}
+
+struct AIConfigResponse: Codable {
+    let ai: AIConfig
+}

--- a/ArtazzenMobile/Sources/Models/Artwork.swift
+++ b/ArtazzenMobile/Sources/Models/Artwork.swift
@@ -23,15 +23,27 @@ struct Artwork: Codable, Identifiable, Hashable {
         case title, caption, description, tags
     }
 
+    var url: String?
+
     enum CodingKeys: String, CodingKey {
         case filename, title, description, caption, tags
-        case artist, copyright, collection, status
+        case artist, copyright, collection, status, url
         case aiGenerated = "ai_generated"
         case aiFields = "ai_fields"
         case detectedAt = "detected_at"
     }
 
-    var imageURL: URL? { nil }
+    var imageURL: URL? {
+        if let url, !url.isEmpty {
+            return URL(string: url)
+        }
+        return nil
+    }
+
+    func imageURL(relativeTo base: URL) -> URL? {
+        if let resolved = imageURL { return resolved }
+        return base.appendingPathComponent("static/images/\(filename)")
+    }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(filename)

--- a/ArtazzenMobile/Sources/Models/Artwork.swift
+++ b/ArtazzenMobile/Sources/Models/Artwork.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct Artwork: Codable, Identifiable, Hashable {
+    var id: String { filename }
+    let filename: String
+    var title: String
+    var description: String
+    var caption: String
+    var tags: [String]
+    var artist: String
+    var copyright: String
+    var collection: String
+    var status: ArtworkStatus
+    var aiGenerated: Bool
+    var aiFields: [AIField]
+    let detectedAt: Double
+
+    enum ArtworkStatus: String, Codable, CaseIterable {
+        case pending, approved, hidden
+    }
+
+    enum AIField: String, Codable, CaseIterable {
+        case title, caption, description, tags
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case filename, title, description, caption, tags
+        case artist, copyright, collection, status
+        case aiGenerated = "ai_generated"
+        case aiFields = "ai_fields"
+        case detectedAt = "detected_at"
+    }
+
+    var imageURL: URL? { nil }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(filename)
+    }
+
+    static func == (lhs: Artwork, rhs: Artwork) -> Bool {
+        lhs.filename == rhs.filename
+    }
+}

--- a/ArtazzenMobile/Sources/Models/DesignTokens.swift
+++ b/ArtazzenMobile/Sources/Models/DesignTokens.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension Color {
+    static let azCarbon = Color(red: 0x12 / 255.0, green: 0x12 / 255.0, blue: 0x12 / 255.0)
+    static let azParchment = Color(red: 0xF9 / 255.0, green: 0xF7 / 255.0, blue: 0xF2 / 255.0)
+    static let azTeal = Color(red: 0x0D / 255.0, green: 0x94 / 255.0, blue: 0x88 / 255.0)
+    static let azOrange = Color(red: 0xF9 / 255.0, green: 0x73 / 255.0, blue: 0x16 / 255.0)
+    static let azViolet = Color(red: 0x8B / 255.0, green: 0x5C / 255.0, blue: 0xF6 / 255.0)
+}
+
+extension Font {
+    static let azDisplay = Font.custom("ClashGrotesk-Bold", size: 28)
+    static let azBody = Font.custom("InstrumentSans-Regular", size: 16)
+    static let azMono = Font.custom("JetBrainsMono-Regular", size: 13)
+}

--- a/ArtazzenMobile/Sources/Services/ArtazzenAPI.swift
+++ b/ArtazzenMobile/Sources/Services/ArtazzenAPI.swift
@@ -14,9 +14,13 @@ actor ArtazzenAPI {
         return "Basic \(encoded)"
     }
 
+    private func resolveURL(_ path: String) -> URL {
+        let clean = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        return URL(string: clean, relativeTo: baseURL) ?? baseURL.appendingPathComponent(clean)
+    }
+
     private func request(_ path: String, method: String = "GET", body: Data? = nil) async throws -> Data {
-        let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
-        var req = URLRequest(url: baseURL.appendingPathComponent(cleanPath))
+        var req = URLRequest(url: resolveURL(path))
         req.httpMethod = method
         req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
         if let body {
@@ -60,7 +64,7 @@ actor ArtazzenAPI {
             URLQueryItem(name: "action", value: "save"),
         ]
         let body = components.percentEncodedQuery?.data(using: .utf8)
-        var req = URLRequest(url: baseURL.appendingPathComponent("admin/metadata/\(artwork.filename)"))
+        var req = URLRequest(url: resolveURL("admin/metadata/\(artwork.filename)"))
         req.httpMethod = "POST"
         req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
         req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
@@ -99,7 +103,7 @@ actor ArtazzenAPI {
 
     func upload(imageData: Data, filename: String) async throws {
         let boundary = UUID().uuidString
-        var req = URLRequest(url: baseURL.appendingPathComponent("admin/upload"))
+        var req = URLRequest(url: resolveURL("admin/upload"))
         req.httpMethod = "POST"
         req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
         req.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")

--- a/ArtazzenMobile/Sources/Services/ArtazzenAPI.swift
+++ b/ArtazzenMobile/Sources/Services/ArtazzenAPI.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+actor ArtazzenAPI {
+    let baseURL: URL
+    private let credentials: (username: String, password: String)
+
+    init(baseURL: URL, username: String, password: String) {
+        self.baseURL = baseURL
+        self.credentials = (username, password)
+    }
+
+    private func authHeader() -> String {
+        let encoded = Data("\(credentials.username):\(credentials.password)".utf8).base64EncodedString()
+        return "Basic \(encoded)"
+    }
+
+    private func request(_ path: String, method: String = "GET", body: Data? = nil) async throws -> Data {
+        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+        req.httpMethod = method
+        req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
+        if let body {
+            req.httpBody = body
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let (data, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw APIError.requestFailed
+        }
+        return data
+    }
+
+    struct PendingResponse: Codable {
+        let pending: [ArtworkWrapper]
+        let gallery: [ArtworkWrapper]
+    }
+
+    struct ArtworkWrapper: Codable {
+        let name: String
+        let url: String
+        let title: String?
+        let metadata: Artwork?
+    }
+
+    func fetchFiles() async throws -> PendingResponse {
+        let data = try await request("/admin/api/new-files")
+        return try JSONDecoder().decode(PendingResponse.self, from: data)
+    }
+
+    func saveMetadata(_ artwork: Artwork) async throws {
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "title", value: artwork.title),
+            URLQueryItem(name: "description", value: artwork.description),
+            URLQueryItem(name: "caption", value: artwork.caption),
+            URLQueryItem(name: "tags", value: artwork.tags.joined(separator: ", ")),
+            URLQueryItem(name: "artist", value: artwork.artist),
+            URLQueryItem(name: "copyright", value: artwork.copyright),
+            URLQueryItem(name: "collection", value: artwork.collection),
+            URLQueryItem(name: "action", value: "save"),
+        ]
+        let body = components.percentEncodedQuery?.data(using: .utf8)
+        var req = URLRequest(url: baseURL.appendingPathComponent("/admin/metadata/\(artwork.filename)"))
+        req.httpMethod = "POST"
+        req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        req.httpBody = body
+        let (_, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse, 200..<400 ~= http.statusCode else {
+            throw APIError.requestFailed
+        }
+    }
+
+    struct RegenRequest: Codable {
+        let images: [String]
+        let fields: [String]?
+        let force: Bool
+    }
+
+    struct RegenResponse: Codable {
+        struct Updated: Codable {
+            let name: String
+            let metadata: Artwork
+        }
+        let updated: [Updated]
+        let errors: [[String: String]]
+    }
+
+    func regenerateFields(image: String, fields: [Artwork.AIField], force: Bool = true) async throws -> Artwork? {
+        let body = try JSONEncoder().encode(RegenRequest(
+            images: [image],
+            fields: fields.map(\.rawValue),
+            force: force
+        ))
+        let data = try await request("/admin/ai/regenerate", method: "POST", body: body)
+        let response = try JSONDecoder().decode(RegenResponse.self, from: data)
+        return response.updated.first?.metadata
+    }
+
+    func upload(imageData: Data, filename: String) async throws {
+        let boundary = UUID().uuidString
+        var req = URLRequest(url: baseURL.appendingPathComponent("/admin/upload"))
+        req.httpMethod = "POST"
+        req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
+        req.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"files\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(imageData)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        req.httpBody = body
+
+        let (_, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw APIError.requestFailed
+        }
+    }
+
+    func unapprove(_ name: String) async throws {
+        _ = try await request("/admin/unapprove/\(name)", method: "POST")
+    }
+
+    func delete(_ name: String) async throws {
+        _ = try await request("/admin/delete/\(name)", method: "POST")
+    }
+
+    func fetchCollections() async throws -> [String] {
+        struct Response: Codable { let collections: [String] }
+        let data = try await request("/admin/api/collections")
+        return try JSONDecoder().decode(Response.self, from: data).collections
+    }
+
+    func fetchConfig() async throws -> AIConfig {
+        let data = try await request("/admin/config")
+        return try JSONDecoder().decode(AIConfigResponse.self, from: data).ai
+    }
+
+    enum APIError: Error {
+        case requestFailed
+    }
+}

--- a/ArtazzenMobile/Sources/Services/ArtazzenAPI.swift
+++ b/ArtazzenMobile/Sources/Services/ArtazzenAPI.swift
@@ -15,7 +15,8 @@ actor ArtazzenAPI {
     }
 
     private func request(_ path: String, method: String = "GET", body: Data? = nil) async throws -> Data {
-        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+        let cleanPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        var req = URLRequest(url: baseURL.appendingPathComponent(cleanPath))
         req.httpMethod = method
         req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
         if let body {

--- a/ArtazzenMobile/Sources/Services/ArtazzenAPI.swift
+++ b/ArtazzenMobile/Sources/Services/ArtazzenAPI.swift
@@ -60,7 +60,7 @@ actor ArtazzenAPI {
             URLQueryItem(name: "action", value: "save"),
         ]
         let body = components.percentEncodedQuery?.data(using: .utf8)
-        var req = URLRequest(url: baseURL.appendingPathComponent("/admin/metadata/\(artwork.filename)"))
+        var req = URLRequest(url: baseURL.appendingPathComponent("admin/metadata/\(artwork.filename)"))
         req.httpMethod = "POST"
         req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
         req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
@@ -99,7 +99,7 @@ actor ArtazzenAPI {
 
     func upload(imageData: Data, filename: String) async throws {
         let boundary = UUID().uuidString
-        var req = URLRequest(url: baseURL.appendingPathComponent("/admin/upload"))
+        var req = URLRequest(url: baseURL.appendingPathComponent("admin/upload"))
         req.httpMethod = "POST"
         req.setValue(authHeader(), forHTTPHeaderField: "Authorization")
         req.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")

--- a/ArtazzenMobile/Sources/Views/Capture/CaptureView.swift
+++ b/ArtazzenMobile/Sources/Views/Capture/CaptureView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import PhotosUI
+
+struct CaptureView: View {
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var imageData: Data?
+    @State private var isProcessing = false
+    @State private var generatedArtwork: Artwork?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                if let imageData, let uiImage = UIImage(data: imageData) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxHeight: 300)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                    if isProcessing {
+                        ProgressView("Generating metadata...")
+                            .font(.azBody)
+                    } else if let artwork = generatedArtwork {
+                        MetadataEditor(artwork: artwork)
+                    }
+                } else {
+                    ContentUnavailableView {
+                        Label("Capture Artwork", systemImage: "camera.viewfinder")
+                    } description: {
+                        Text("Take a photo or choose from your library to add artwork.")
+                    }
+                }
+            }
+            .padding()
+            .navigationTitle("Capture")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    PhotosPicker(selection: $selectedItem, matching: .images) {
+                        Label("Choose", systemImage: "photo.on.rectangle")
+                    }
+                }
+            }
+            .onChange(of: selectedItem) { _, item in
+                Task {
+                    guard let data = try? await item?.loadTransferable(type: Data.self) else { return }
+                    imageData = data
+                    isProcessing = true
+                    // Upload would happen here via ArtazzenAPI
+                    isProcessing = false
+                }
+            }
+        }
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Capture/CaptureView.swift
+++ b/ArtazzenMobile/Sources/Views/Capture/CaptureView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PhotosUI
+import UIKit
 
 struct CaptureView: View {
     @State private var selectedItem: PhotosPickerItem?

--- a/ArtazzenMobile/Sources/Views/Capture/MetadataEditor.swift
+++ b/ArtazzenMobile/Sources/Views/Capture/MetadataEditor.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct MetadataEditor: View {
+    @State var artwork: Artwork
+    @State private var tagText: String = ""
+
+    var body: some View {
+        Form {
+            Section("Basic Info") {
+                AIFieldRow(label: "Title", field: .title, artwork: $artwork) {
+                    TextField("Title", text: $artwork.title)
+                }
+                AIFieldRow(label: "Caption", field: .caption, artwork: $artwork) {
+                    TextField("Caption", text: $artwork.caption)
+                }
+                AIFieldRow(label: "Description", field: .description, artwork: $artwork) {
+                    TextField("Description", text: $artwork.description, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+            }
+
+            Section("Details") {
+                TextField("Artist", text: $artwork.artist)
+                TextField("Copyright", text: $artwork.copyright)
+                TextField("Collection", text: $artwork.collection)
+            }
+
+            Section("Tags") {
+                AIFieldRow(label: "Tags", field: .tags, artwork: $artwork) {
+                    HStack(spacing: 6) {
+                        ForEach(artwork.tags, id: \.self) { tag in
+                            TagPill(text: tag)
+                        }
+                    }
+                }
+                HStack {
+                    TextField("Add tag", text: $tagText)
+                        .onSubmit {
+                            let tag = tagText.trimmingCharacters(in: .whitespaces).lowercased()
+                            if !tag.isEmpty && !artwork.tags.contains(tag) {
+                                artwork.tags.append(tag)
+                            }
+                            tagText = ""
+                        }
+                    Button("Add") {
+                        let tag = tagText.trimmingCharacters(in: .whitespaces).lowercased()
+                        if !tag.isEmpty && !artwork.tags.contains(tag) {
+                            artwork.tags.append(tag)
+                        }
+                        tagText = ""
+                    }
+                }
+            }
+
+            Section {
+                Button("Save & Approve") {
+                    // API call via ArtazzenAPI.saveMetadata
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Color.azTeal)
+            }
+        }
+        .font(.azBody)
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Gallery/ArtworkDetailView.swift
+++ b/ArtazzenMobile/Sources/Views/Gallery/ArtworkDetailView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct ArtworkDetailView: View {
+    let artwork: Artwork
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                AsyncImage(url: artwork.imageURL) { image in
+                    image.resizable().aspectRatio(contentMode: .fit)
+                } placeholder: {
+                    Rectangle().fill(Color.azCarbon.opacity(0.1))
+                        .aspectRatio(4 / 5, contentMode: .fit)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(artwork.title)
+                        .font(.azDisplay)
+
+                    if !artwork.caption.isEmpty {
+                        Text(artwork.caption)
+                            .font(.azBody)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if !artwork.description.isEmpty {
+                        Text(artwork.description)
+                            .font(.azBody)
+                            .lineSpacing(4)
+                    }
+
+                    if !artwork.artist.isEmpty {
+                        MetadataRow(label: "Artist", value: artwork.artist)
+                    }
+
+                    if !artwork.tags.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Tags")
+                                .font(.azMono)
+                                .foregroundStyle(.secondary)
+                            HStack(spacing: 6) {
+                                ForEach(artwork.tags, id: \.self) { tag in
+                                    TagPill(text: tag)
+                                }
+                            }
+                        }
+                    }
+
+                    if !artwork.collection.isEmpty {
+                        MetadataRow(label: "Collection", value: artwork.collection)
+                    }
+
+                    if !artwork.copyright.isEmpty {
+                        MetadataRow(label: "Copyright", value: artwork.copyright)
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .navigationTitle(artwork.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct MetadataRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.azMono)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.azBody)
+        }
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Gallery/GalleryGrid.swift
+++ b/ArtazzenMobile/Sources/Views/Gallery/GalleryGrid.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+enum GalleryGrid {
+    struct Cell: View {
+        let artwork: Artwork
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 6) {
+                AsyncImage(url: artwork.imageURL) { image in
+                    image.resizable().aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Rectangle().fill(Color.azCarbon.opacity(0.1))
+                }
+                .frame(minHeight: 160)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .overlay(alignment: .topTrailing) {
+                    StatusBadge(status: artwork.status)
+                        .padding(6)
+                }
+
+                Text(artwork.title)
+                    .font(.azBody)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .foregroundStyle(Color.primary)
+
+                if !artwork.caption.isEmpty {
+                    Text(artwork.caption)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Gallery/GalleryView.swift
+++ b/ArtazzenMobile/Sources/Views/Gallery/GalleryView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct GalleryView: View {
+    @State private var artworks: [Artwork] = []
+    @State private var searchText = ""
+    @State private var selectedCollection: String?
+    @State private var collections: [String] = []
+
+    private let columns = [GridItem(.adaptive(minimum: 160), spacing: 12)]
+
+    var filtered: [Artwork] {
+        artworks.filter { art in
+            art.status == .approved
+            && (selectedCollection == nil || art.collection == selectedCollection)
+            && (searchText.isEmpty || art.title.lowercased().contains(searchText.lowercased()))
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 12) {
+                    ForEach(filtered) { artwork in
+                        NavigationLink(value: artwork) {
+                            GalleryGrid.Cell(artwork: artwork)
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Gallery")
+            .searchable(text: $searchText, prompt: "Search artwork")
+            .toolbar {
+                if !collections.isEmpty {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Menu {
+                            Button("All Collections") { selectedCollection = nil }
+                            ForEach(collections, id: \.self) { col in
+                                Button(col) { selectedCollection = col }
+                            }
+                        } label: {
+                            Label("Collection", systemImage: "folder")
+                        }
+                    }
+                }
+            }
+            .navigationDestination(for: Artwork.self) { artwork in
+                ArtworkDetailView(artwork: artwork)
+            }
+        }
+    }
+}

--- a/ArtazzenMobile/Sources/Views/MainTabView.swift
+++ b/ArtazzenMobile/Sources/Views/MainTabView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct MainTabView: View {
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            QueueView()
+                .tabItem {
+                    Label("Queue", systemImage: "list.bullet")
+                }
+                .tag(0)
+
+            SwipeDeckView()
+                .tabItem {
+                    Label("Review", systemImage: "rectangle.stack")
+                }
+                .tag(1)
+
+            CaptureView()
+                .tabItem {
+                    Label("Capture", systemImage: "camera")
+                }
+                .tag(2)
+
+            GalleryView()
+                .tabItem {
+                    Label("Gallery", systemImage: "photo.on.rectangle")
+                }
+                .tag(3)
+
+            SettingsView()
+                .tabItem {
+                    Label("Settings", systemImage: "gear")
+                }
+                .tag(4)
+        }
+        .tint(Color.azTeal)
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Queue/QueueCard.swift
+++ b/ArtazzenMobile/Sources/Views/Queue/QueueCard.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct QueueCard: View {
+    let artwork: Artwork
+
+    var body: some View {
+        HStack(spacing: 12) {
+            AsyncImage(url: artwork.imageURL) { image in
+                image.resizable().aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Rectangle().fill(Color.azCarbon.opacity(0.1))
+            }
+            .frame(width: 64, height: 64)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(artwork.title)
+                    .font(.azBody)
+                    .lineLimit(1)
+                Text(artwork.filename)
+                    .font(.azMono)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                StatusBadge(status: artwork.status)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Queue/QueueView.swift
+++ b/ArtazzenMobile/Sources/Views/Queue/QueueView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct QueueView: View {
+    @State private var artworks: [Artwork] = []
+    @State private var searchText = ""
+    @State private var statusFilter: Artwork.ArtworkStatus? = .pending
+
+    var filtered: [Artwork] {
+        artworks.filter { art in
+            if let filter = statusFilter, art.status != filter { return false }
+            if searchText.isEmpty { return true }
+            let q = searchText.lowercased()
+            return art.title.lowercased().contains(q)
+                || art.description.lowercased().contains(q)
+                || art.tags.contains(where: { $0.lowercased().contains(q) })
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List(filtered) { artwork in
+                NavigationLink(value: artwork) {
+                    QueueCard(artwork: artwork)
+                }
+            }
+            .navigationTitle("Queue")
+            .searchable(text: $searchText, prompt: "Search artwork")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button("All") { statusFilter = nil }
+                        ForEach(Artwork.ArtworkStatus.allCases, id: \.self) { s in
+                            Button(s.rawValue.capitalized) { statusFilter = s }
+                        }
+                    } label: {
+                        Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+                    }
+                }
+            }
+            .navigationDestination(for: Artwork.self) { artwork in
+                ArtworkDetailView(artwork: artwork)
+            }
+        }
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Review/ReviewCard.swift
+++ b/ArtazzenMobile/Sources/Views/Review/ReviewCard.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct ReviewCard: View {
+    let artwork: Artwork
+
+    var body: some View {
+        VStack(spacing: 0) {
+            AsyncImage(url: artwork.imageURL) { image in
+                image.resizable().aspectRatio(contentMode: .fit)
+            } placeholder: {
+                Rectangle().fill(Color.azCarbon.opacity(0.1))
+                    .aspectRatio(4 / 5, contentMode: .fit)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(artwork.title)
+                    .font(.azDisplay)
+                    .lineLimit(2)
+
+                if !artwork.caption.isEmpty {
+                    Text(artwork.caption)
+                        .font(.azBody)
+                        .foregroundStyle(.secondary)
+                }
+
+                if !artwork.tags.isEmpty {
+                    HStack(spacing: 6) {
+                        ForEach(artwork.tags.prefix(5), id: \.self) { tag in
+                            TagPill(text: tag)
+                        }
+                    }
+                }
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color.azParchment)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(radius: 8, y: 4)
+        .padding(.horizontal, 20)
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Review/ReviewCard.swift
+++ b/ArtazzenMobile/Sources/Views/Review/ReviewCard.swift
@@ -36,7 +36,7 @@ struct ReviewCard: View {
         }
         .background(Color.azParchment)
         .clipShape(RoundedRectangle(cornerRadius: 12))
-        .shadow(radius: 8, y: 4)
+        .shadow(radius: 8, x: 0, y: 4)
         .padding(.horizontal, 20)
     }
 }

--- a/ArtazzenMobile/Sources/Views/Review/SwipeDeckView.swift
+++ b/ArtazzenMobile/Sources/Views/Review/SwipeDeckView.swift
@@ -3,9 +3,10 @@ import SwiftUI
 struct SwipeDeckView: View {
     @State private var pending: [Artwork] = []
     @State private var offset: CGSize = .zero
-    @State private var currentIndex = 0
 
     private let threshold: CGFloat = 120
+
+    private var topID: String? { pending.first?.id }
 
     var body: some View {
         NavigationStack {
@@ -18,12 +19,13 @@ struct SwipeDeckView: View {
                     )
                 } else {
                     ForEach(Array(pending.enumerated().reversed()), id: \.element.id) { index, artwork in
+                        let isTop = (index == 0)
                         ReviewCard(artwork: artwork)
-                            .offset(index == currentIndex ? offset : .zero)
-                            .rotationEffect(.degrees(index == currentIndex ? Double(offset.width) / 20 : 0))
-                            .scaleEffect(index == currentIndex ? 1.0 : 0.95)
+                            .offset(isTop ? offset : .zero)
+                            .rotationEffect(.degrees(isTop ? Double(offset.width) / 20 : 0))
+                            .scaleEffect(isTop ? 1.0 : 0.95)
                             .gesture(
-                                index == currentIndex ?
+                                isTop ?
                                 DragGesture()
                                     .onChanged { value in
                                         offset = value.translation
@@ -69,7 +71,7 @@ struct SwipeDeckView: View {
             offset = CGSize(width: 500, height: 0)
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            advanceCard()
+            removeTopCard()
         }
     }
 
@@ -78,16 +80,13 @@ struct SwipeDeckView: View {
             offset = CGSize(width: -500, height: 0)
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            advanceCard()
+            removeTopCard()
         }
     }
 
-    private func advanceCard() {
-        guard currentIndex < pending.count - 1 else {
-            pending.removeAll()
-            return
-        }
-        currentIndex += 1
+    private func removeTopCard() {
+        guard !pending.isEmpty else { return }
+        pending.removeFirst()
         offset = .zero
     }
 }

--- a/ArtazzenMobile/Sources/Views/Review/SwipeDeckView.swift
+++ b/ArtazzenMobile/Sources/Views/Review/SwipeDeckView.swift
@@ -25,7 +25,6 @@ struct SwipeDeckView: View {
                             .rotationEffect(.degrees(isTop ? Double(offset.width) / 20 : 0))
                             .scaleEffect(isTop ? 1.0 : 0.95)
                             .gesture(
-                                isTop ?
                                 DragGesture()
                                     .onChanged { value in
                                         offset = value.translation
@@ -39,8 +38,8 @@ struct SwipeDeckView: View {
                                             withAnimation(.spring()) { offset = .zero }
                                         }
                                     }
-                                : nil
                             )
+                            .allowsHitTesting(isTop)
                             .animation(.spring(), value: offset)
                     }
 

--- a/ArtazzenMobile/Sources/Views/Review/SwipeDeckView.swift
+++ b/ArtazzenMobile/Sources/Views/Review/SwipeDeckView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+struct SwipeDeckView: View {
+    @State private var pending: [Artwork] = []
+    @State private var offset: CGSize = .zero
+    @State private var currentIndex = 0
+
+    private let threshold: CGFloat = 120
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                if pending.isEmpty {
+                    ContentUnavailableView(
+                        "No Pending Artwork",
+                        systemImage: "checkmark.circle",
+                        description: Text("All artwork has been reviewed.")
+                    )
+                } else {
+                    ForEach(Array(pending.enumerated().reversed()), id: \.element.id) { index, artwork in
+                        ReviewCard(artwork: artwork)
+                            .offset(index == currentIndex ? offset : .zero)
+                            .rotationEffect(.degrees(index == currentIndex ? Double(offset.width) / 20 : 0))
+                            .scaleEffect(index == currentIndex ? 1.0 : 0.95)
+                            .gesture(
+                                index == currentIndex ?
+                                DragGesture()
+                                    .onChanged { value in
+                                        offset = value.translation
+                                    }
+                                    .onEnded { value in
+                                        if value.translation.width > threshold {
+                                            approve()
+                                        } else if value.translation.width < -threshold {
+                                            hide()
+                                        } else {
+                                            withAnimation(.spring()) { offset = .zero }
+                                        }
+                                    }
+                                : nil
+                            )
+                            .animation(.spring(), value: offset)
+                    }
+
+                    VStack {
+                        Spacer()
+                        HStack(spacing: 48) {
+                            Button { hide() } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .font(.system(size: 44))
+                                    .foregroundStyle(Color.azOrange)
+                            }
+                            Button { approve() } label: {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .font(.system(size: 44))
+                                    .foregroundStyle(Color.azTeal)
+                            }
+                        }
+                        .padding(.bottom, 32)
+                    }
+                }
+            }
+            .navigationTitle("Review")
+        }
+    }
+
+    private func approve() {
+        withAnimation(.easeOut(duration: 0.3)) {
+            offset = CGSize(width: 500, height: 0)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            advanceCard()
+        }
+    }
+
+    private func hide() {
+        withAnimation(.easeOut(duration: 0.3)) {
+            offset = CGSize(width: -500, height: 0)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            advanceCard()
+        }
+    }
+
+    private func advanceCard() {
+        guard currentIndex < pending.count - 1 else {
+            pending.removeAll()
+            return
+        }
+        currentIndex += 1
+        offset = .zero
+    }
+}

--- a/ArtazzenMobile/Sources/Views/Settings/SettingsView.swift
+++ b/ArtazzenMobile/Sources/Views/Settings/SettingsView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var config = AIConfig(enabled: true, model: "gpt-4o-mini", temperature: 0.6, maxOutputTokens: 600)
+    @AppStorage("az-dark-mode") private var darkMode = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Appearance") {
+                    Toggle("Dark Mode", isOn: $darkMode)
+                }
+
+                Section("AI Metadata") {
+                    Toggle("Enable AI Generation", isOn: $config.enabled)
+
+                    Picker("Model", selection: $config.model) {
+                        Text("gpt-4o-mini").tag("gpt-4o-mini")
+                        Text("gpt-5-mini").tag("gpt-5-mini")
+                    }
+
+                    HStack {
+                        Text("Temperature")
+                        Spacer()
+                        Text(String(format: "%.1f", config.temperature))
+                            .font(.azMono)
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(value: $config.temperature, in: 0...2, step: 0.1)
+
+                    Stepper("Max Tokens: \(config.maxOutputTokens)", value: $config.maxOutputTokens, in: 16...4000, step: 50)
+                }
+
+                Section {
+                    Button("Save Settings") {
+                        // API call via ArtazzenAPI
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Color.azTeal)
+
+                    Button("Reset to Defaults", role: .destructive) {
+                        config = AIConfig(enabled: true, model: "gpt-4o-mini", temperature: 0.6, maxOutputTokens: 600)
+                    }
+                }
+
+                Section("About") {
+                    LabeledContent("Server", value: "artazzen.com")
+                    LabeledContent("Version", value: "1.0.0")
+                }
+            }
+            .navigationTitle("Settings")
+        }
+    }
+}

--- a/ArtazzenMobile/Tests/ArtazzenMobileTests/ArtworkTests.swift
+++ b/ArtazzenMobile/Tests/ArtazzenMobileTests/ArtworkTests.swift
@@ -32,6 +32,8 @@ final class ArtworkTests: XCTestCase {
         XCTAssertTrue(artwork.aiGenerated)
         XCTAssertEqual(artwork.aiFields, [.title, .description])
         XCTAssertEqual(artwork.id, "test.jpg")
+        XCTAssertNil(artwork.url)
+        XCTAssertNil(artwork.imageURL)
     }
 
     func testEncode() throws {

--- a/ArtazzenMobile/Tests/ArtazzenMobileTests/ArtworkTests.swift
+++ b/ArtazzenMobile/Tests/ArtazzenMobileTests/ArtworkTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import ArtazzenMobile
+
+final class ArtworkTests: XCTestCase {
+    let sampleJSON = """
+    {
+        "filename": "test.jpg",
+        "title": "Test Artwork",
+        "description": "A test description",
+        "caption": "Test caption",
+        "tags": ["abstract", "botanical"],
+        "artist": "Test Artist",
+        "copyright": "© 2026",
+        "collection": "Test Collection",
+        "status": "approved",
+        "ai_generated": true,
+        "ai_fields": ["title", "description"],
+        "detected_at": 1718000000.0
+    }
+    """.data(using: .utf8)!
+
+    func testDecode() throws {
+        let artwork = try JSONDecoder().decode(Artwork.self, from: sampleJSON)
+        XCTAssertEqual(artwork.filename, "test.jpg")
+        XCTAssertEqual(artwork.title, "Test Artwork")
+        XCTAssertEqual(artwork.caption, "Test caption")
+        XCTAssertEqual(artwork.tags, ["abstract", "botanical"])
+        XCTAssertEqual(artwork.artist, "Test Artist")
+        XCTAssertEqual(artwork.copyright, "© 2026")
+        XCTAssertEqual(artwork.collection, "Test Collection")
+        XCTAssertEqual(artwork.status, .approved)
+        XCTAssertTrue(artwork.aiGenerated)
+        XCTAssertEqual(artwork.aiFields, [.title, .description])
+        XCTAssertEqual(artwork.id, "test.jpg")
+    }
+
+    func testEncode() throws {
+        let artwork = try JSONDecoder().decode(Artwork.self, from: sampleJSON)
+        let encoded = try JSONEncoder().encode(artwork)
+        let decoded = try JSONDecoder().decode(Artwork.self, from: encoded)
+        XCTAssertEqual(artwork.filename, decoded.filename)
+        XCTAssertEqual(artwork.tags, decoded.tags)
+        XCTAssertEqual(artwork.aiFields, decoded.aiFields)
+    }
+
+    func testPendingStatus() throws {
+        let json = """
+        {
+            "filename": "pending.jpg",
+            "title": "",
+            "description": "",
+            "caption": "",
+            "tags": [],
+            "artist": "",
+            "copyright": "",
+            "collection": "",
+            "status": "pending",
+            "ai_generated": false,
+            "ai_fields": [],
+            "detected_at": 0
+        }
+        """.data(using: .utf8)!
+        let artwork = try JSONDecoder().decode(Artwork.self, from: json)
+        XCTAssertEqual(artwork.status, .pending)
+        XCTAssertFalse(artwork.aiGenerated)
+        XCTAssertTrue(artwork.aiFields.isEmpty)
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,3 +174,22 @@ Follow the four Karpathy principles:
 2. **Simplicity First** — Prefer the simplest solution that works.
 3. **Surgical Changes** — Minimize diff size; touch only what's needed.
 4. **Goal-Driven Execution** — Stay focused on the stated objective.
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+- Product ideas/brainstorming → invoke /office-hours
+- Strategy/scope → invoke /plan-ceo-review
+- Architecture → invoke /plan-eng-review
+- Design system/plan review → invoke /design-consultation or /plan-design-review
+- Full review pipeline → invoke /autoplan
+- Bugs/errors → invoke /investigate
+- QA/testing site behavior → invoke /qa or /qa-only
+- Code review/diff check → invoke /review
+- Visual polish → invoke /design-review
+- Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Save progress → invoke /context-save
+- Resume context → invoke /context-restore
+- Author a backlog-ready spec/issue → invoke /spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ Follow the four Karpathy principles:
 When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
 
 Key routing rules:
+
 - Product ideas/brainstorming → invoke /office-hours
 - Strategy/scope → invoke /plan-ceo-review
 - Architecture → invoke /plan-eng-review

--- a/ImageSidecar.schema.json
+++ b/ImageSidecar.schema.json
@@ -21,7 +21,6 @@
     "ai_details": {
       "type": "object",
       "default": {},
-      "additionalProperties": false,
       "properties": {
         "provider": {
           "type": "string",
@@ -84,6 +83,46 @@
       "type": "number",
       "description": "Unix epoch seconds when the image was first detected.",
       "default": 0
+    },
+    "caption": {
+      "type": "string",
+      "default": "",
+      "description": "Short gallery caption for the artwork."
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Descriptive tags for categorization and search."
+    },
+    "artist": {
+      "type": "string",
+      "default": "",
+      "description": "Artist or creator name."
+    },
+    "author": {
+      "type": "string",
+      "default": "",
+      "description": "Deprecated: use artist field instead. Kept for backwards compatibility."
+    },
+    "copyright": {
+      "type": "string",
+      "default": "",
+      "description": "Copyright or license information."
+    },
+    "collection": {
+      "type": "string",
+      "default": "",
+      "description": "Collection or series this artwork belongs to."
+    },
+    "ai_fields": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["title", "caption", "description", "tags"]
+      },
+      "default": [],
+      "description": "Which metadata fields were generated or last updated by AI."
     }
   },
   "required": [

--- a/ImageSidecar.schema.json
+++ b/ImageSidecar.schema.json
@@ -66,7 +66,8 @@
           "type": "object",
           "default": {}
         }
-      }
+      },
+      "additionalProperties": false
     },
     "status": {
       "type": "string",

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,223 +1,326 @@
-<!-- /autoplan restore point: /home/allisone/.gstack/projects/adamtasteslikegood-ArtazzenDotCom/docs-production-infra-autoplan-restore-20260816-050641.md -->
+# Plan: Artazzen Mobile — Schema v2 + Mobile Web + SwiftUI Spec
 
-# Plan: Admin Page Gallery Curation & UI Overhaul
+> Supersedes the "Admin Page Gallery Curation & UI Overhaul" plan.
+> Source: Claude Design project `0d04de68-334e-4421-8f13-7595824d032b` ("Artazzen Mobile")
+> Date: 2026-08-18 | Branch: `feat/artazzen-mobile`
 
-## Problem
+## Overview
 
-The admin page currently only shows unreviewed ("pending") images. Once an image is reviewed (`reviewed: true`), it vanishes from admin entirely — the owner has no way to see, search, edit, or un-approve gallery items. The public gallery shows ALL images regardless of review status, meaning unreviewed uploads appear publicly immediately.
+Two-track deliverable from the Artazzen Mobile design prototype:
 
-The card layout, search/filtering, and introductory content are also missing or broken.
+- **Track A (Mobile Web)** — Add mobile-responsive views and missing functionality to the existing FastAPI + Jinja2 app
+- **Track B (SwiftUI Spec)** — Author a standalone iOS 17+ app specification (specs only — cannot build/test on Linux)
 
-## Goals
+Both tracks share a backend contract: schema v2, updated API endpoints, and sidecar migration.
 
-### Phase A — Content-control fix (ship first, separate PR)
+## Taste Decisions (for user at gate)
 
-1. **Public gallery shows only reviewed images** — filter `get_artwork_files()` to return only `reviewed: true`
-2. **Bulk migration** — one-shot script to set `reviewed: true` on all existing ~184 images so the gallery doesn't go empty
+1. **`author` vs `artist`**: Existing sidecars and AI prompt use `author`. Design spec says `artist`. Recommend: adopt `artist` per design, migrate `author` → `artist`, keep `author` in schema as deprecated (same pattern as `reviewed`).
 
-### Phase B — Admin curation overhaul
+## Current State (empirical findings)
 
-3. **Separate pending/gallery sections on admin** — two distinct views: "Pending Review" (unreviewed) and "Gallery" (approved/reviewed) with counts
-4. **Search bar filtering** — client-side filtering by title/description/filename across both admin sections, with server-side pagination (50 per page)
-5. **Pretext/hero** — introductory text on the public gallery and admin dashboard; update gallery title from placeholder
-6. **Card layout fix** — fix admin `.admin-container` grid so pending/gallery sections span full width; verify public gallery grid
-7. **Full gallery curation** — from the admin gallery section: edit metadata, un-approve (move back to pending), soft-delete (move to `.trash/` subdirectory)
-8. **Admin navigation** — tab bar in header for Dashboard / Settings with active states
-9. **Settings page** — move AI config to its own `/admin/settings` route/template
+- **Schema validation is broken**: `manage_sidecars.py validate` fails on dozens of sidecars — they contain `author`, `caption`, `copyright`, `tags` which `additionalProperties: false` rejects. The app tolerates this silently at runtime (`_validate_and_migrate_sidecars` catches ValidationError, logs a warning, and writes back the sidecar unchanged).
+- **OpenAI prompt is v1**: `_build_openai_prompt()` only requests `title` and `description`. The JSON schema sent to OpenAI only accepts those two fields. Response parser only maps those back. Sidecars with caption/author/tags got them from a previous code version.
+- **Templates partially implemented**: `reviewAddedFiles.html` already has admin tabs (Dashboard/Settings), search bar, gallery/pending sections, upload, action buttons (edit, unapprove, delete). `artwork_detail.html` is minimal — inline styles, 2-column grid, no v2 fields, no mobile responsiveness.
 
-## Scope
+---
 
-### In scope
+## Part 0: Shared Backend (both tracks depend on this)
 
-- Backend: new routes, modify `get_artwork_files()`, add soft-delete/un-approve endpoints, settings route, pagination
-- Templates: refactor `reviewAddedFiles.html` with gallery section + search + nav tabs, new `admin_settings.html`, update `index.html`
-- CSS: fix admin grid, search bar styles, nav tab styles, interaction states
-- Schema: add `status` enum (`pending`/`approved`/`hidden`) to sidecar, replacing `reviewed` boolean
-- Migration: bulk-migrate existing sidecars (`reviewed: true` → `approved`, `reviewed: false` → `pending`)
-- Tests: pytest tests for all new endpoints
+### 0.1 Schema v2 — ImageSidecar.schema.json
 
-### Out of scope
+Update the existing schema. New fields (all with defaults for backwards compat):
 
-- Image reordering/sorting beyond alphabetical
-- User accounts or role-based permissions
-- Full design system visual overhaul (Techno-Botanical implementation deferred)
-- Batch operations beyond existing select-all + AI regen
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `caption` | string | `""` | Already in sidecars, not in schema |
+| `tags` | string[] | `[]` | Already in sidecars, not in schema |
+| `artist` | string | `""` | New canonical name (replaces `author`) |
+| `copyright` | string | `""` | Already in sidecars, not in schema |
+| `collection` | string | `""` | New field |
+| `ai_fields` | string[] (enum: title/caption/description/tags) | `[]` | Tracks which fields AI generated |
+| `author` | string | `""` | **Deprecated** — kept for backwards compat like `reviewed` |
 
-### NOT in scope (deferred to TODOS.md)
+Keep `reviewed` (deprecated). Keep `additionalProperties: false`. Keep `author` as deprecated (do NOT remove — production sidecars on Railway volume would fail validation between deploy and migration run if the field is removed from schema before migration runs).
 
-- Server-side search (client-side sufficient at current scale with pagination)
-- Gallery artwork list caching via watcher (performance optimization, defer until measured)
+**Effect**: Schema v2 immediately fixes the existing validation failures — all currently-present fields become schema-legal.
 
-## Implementation
+### 0.2 Sidecar Migration Script
 
-### Phase A: Content-control fix (separate PR)
+`scripts/migrate_v2.py`:
+1. For each `.json` sidecar in IMAGES_DIR:
+   - Add missing v2 fields with defaults
+   - Copy `author` → `artist` if `author` present and `artist` empty
+   - Keep `author` in the sidecar (deprecated, not removed)
+   - For sidecars with `ai_generated: true`: set `ai_fields: ["title", "description"]` (these are the only fields the v1 prompt actually generated)
+   - For sidecars with `ai_generated: false` or missing: set `ai_fields: []`
+   - Write back atomically (write to `.tmp`, rename)
+2. Validate against updated schema
+3. Report: migrated count, error count, already-current count
+4. Idempotent — safe to re-run
 
-#### A1. Add `status` field to sidecar schema + migration
+### 0.3 manage_sidecars.py Updates
 
-- **File**: `ImageSidecar.schema.json` — add `status` field: enum `["pending", "approved", "hidden"]`, default `"pending"`
-- **File**: `main.py` — update `_load_metadata()`, `_ensure_sidecar()`, `_set_review_status_sidecar()` to use `status` instead of `reviewed`. Keep backwards-compat: if sidecar has `reviewed` but no `status`, convert on read (`reviewed: true` → `"approved"`, `false` → `"pending"`)
-- **New file**: `scripts/migrate_status.py` — bulk-migrate all existing sidecars: add `status` field based on `reviewed` value, remove `reviewed` key
-- **Run before deploying A2** to prevent gallery from going empty
-- **Idempotent**: safe to re-run
+- Import and validate against updated schema
+- Handle v2 fields in report output
 
-#### A2. Filter public gallery to approved-only
+### 0.4 API Endpoint Changes in main.py
 
-- **File**: `main.py` — `get_artwork_files()` (~line 922)
-- **Change**: Add `if meta.get("status", "pending") != "approved": continue` after loading metadata at line 931
-- **Impact**: Public gallery only shows curated work; pending/hidden uploads stay private
+#### 0.4a — Extend `POST /admin/metadata/{image_name}` (line 1336)
 
-### Phase B: Admin curation overhaul
+Add Form fields: `caption`, `tags` (comma-separated string → list), `artist`, `copyright`, `collection`. Merge into sidecar on save.
 
-#### B1. Admin layout restructure
+#### 0.4b — Extend `POST /admin/ai/regenerate` (line 1153)
 
-- **File**: `templates/reviewAddedFiles.html`
-- **Section order (top to bottom)**:
-  1. Header with nav tabs: Dashboard (active) | Settings
-  2. Upload section — full width, collapsible, drag-drop + server path import
-  3. Search bar — full width, `<input type="search">` with JS instant-filter (debounce 200ms, min 0 chars)
-  4. Gallery section — full width, shows `status: "approved"` images with count badge
-  5. Pending section — full width, shows `status: "pending"` images with count badge
-- **Admin grid fix**: Change `.admin-container` so all sections use `grid-column: 1 / -1` (full width)
-- **Gallery cards**: Reuse `.pending-card` layout pattern with additional action buttons
+Add optional `fields` parameter (string[]). When provided, only regenerate the specified fields (title, caption, description, tags). When absent, regenerate all AI-eligible fields (current behavior).
 
-#### B2. Gallery section with curation actions
+**Force-regenerate scope**: v2 force blanks `title`, `description`, `caption`, and `tags` (not just title+description as v1 does).
 
-- **File**: `main.py` — `/admin` route (~line 963)
-- **Change**: Pass both `pending_images` and `gallery_images` to template
-- **New function**: `get_gallery_images()` — scans IMAGES_DIR, returns images where `status: "approved"`
-- **Gallery card actions**:
-  - "Edit" — links to existing `/admin/review/{image_name}` route
-  - "Move to Pending" — calls `POST /admin/unapprove/{image_name}`
-  - "Delete" — calls `POST /admin/delete/{image_name}` (soft-delete)
-- **Interaction states per action**:
-  - Loading: button disabled + spinner icon during fetch
-  - Success: card animates out (CSS transition, 300ms fade), counter updates
-  - Error: inline error message below card, auto-dismiss after 5s
-  - Delete confirmation: inline expand below card ("Are you sure? This moves the image to trash.") with Confirm/Cancel buttons — NOT browser `confirm()` dialog
+Track regenerated fields in `ai_fields` array. Example: if `fields=["caption"]`, only blank `caption`, re-request from AI, and set `ai_fields` to include `"caption"`.
 
-#### B3. New endpoints
+#### 0.4c — New `GET /admin/api/collections` endpoint
 
-- **File**: `main.py`
-- `POST /admin/unapprove/{image_name}`:
-  - Uses `_resolve_image_path()` (path traversal protection)
-  - Uses `Depends(_verify_admin)`
-  - Sets `status: "pending"` in sidecar
-  - Preserves existing AI metadata (title, description, ai_details) — documented behavior
-  - Returns updated pending + gallery lists as JSON
-- `POST /admin/delete/{image_name}`:
-  - Uses `_resolve_image_path()` (path traversal protection)
-  - Uses `Depends(_verify_admin)`
-  - **Soft-delete**: moves image + sidecar to `IMAGES_DIR/.trash/` subdirectory (create if needed)
-  - Acquires `sidecar_lock` before moving files (prevents race with watcher)
-  - Returns updated gallery list as JSON
-  - Uses POST not DELETE (HTML forms can't send DELETE; simpler JS)
+Returns distinct `collection` values from all sidecars. Protected by `_verify_admin` — follows convention of `/admin/api/new-files`. The collections picker serves admin flows; an unauthenticated endpoint would leak pending/hidden curation data.
 
-#### B4. Watcher race condition fix
+```python
+@app.get("/admin/api/collections", response_class=JSONResponse)
+async def list_collections(_: None = Depends(_verify_admin)) -> JSONResponse:
+    ...
+```
 
-- **File**: `main.py` — `new_files_detected()` (~line 700)
-- **Change**: Wrap `_load_metadata` call in try/except for `FileNotFoundError`, skip vanished files
-- **Impact**: Prevents ghost entries when files are deleted mid-scan
+#### 0.4d — Update AI prompt + response pipeline
 
-#### B5. Search bar
+Three functions need changes:
 
-- **File**: `templates/reviewAddedFiles.html`
-- **Placement**: Full-width bar below nav tabs, above gallery/pending sections
-- **Behavior**: JS filters visible cards by matching query against title, description, and filename. Filters both gallery and pending sections simultaneously. Shows "No matches" empty state per section.
-- **Style**: Uses Instrument Sans font, 8px-based padding, matches existing form input styling from `.ai-config-form input`
+1. **`_build_openai_prompt()` (line 395)**: Expand to request `caption`, `tags`, `artist`, `copyright` in addition to `title` and `description`. Make field-aware — only request fields being regenerated.
 
-#### B6. Settings page
+2. **`_request_openai_metadata()` (line 463)**: Update the `json_schema` sent to OpenAI to include `caption` (string), `tags` (array of strings), `artist` (string), `copyright` (string). Update response extraction at line 643 to map all fields from parsed response.
 
-- **File**: `main.py` — new `GET /admin/settings` route with `Depends(_verify_admin)`
-- **New template**: `templates/admin_settings.html`
-- **Content**: AI config form (moved from dashboard), same fetch-based save/reset
-- **Nav**: Header tab "Settings" links here; "Dashboard" links back to `/admin`
+3. **`_populate_missing_metadata()` (line 648)**: Check for missing caption/tags/artist/copyright in addition to title/description. Map all AI-returned fields into sidecar. Update `ai_fields` array with which fields were set by AI.
 
-#### B7. Pretext and gallery title
+### 0.5 Template Context Updates
 
-- **File**: `templates/index.html` — add intro paragraph below header: gallery description text
-- **File**: `templates/reviewAddedFiles.html` — update subheading with contextual dashboard description
-- **File**: `main.py` line 1313 — change gallery title from "My Girlfriend's Artwork Gallery" to proper title (configurable via env var `GALLERY_TITLE`, default "Artazzen Gallery")
-- **New env var**: `GALLERY_TITLE` added to `.env.example`
+All templates that display metadata need the new fields in their context dict. Update template rendering to include v2 fields where displayed.
 
-#### B8. Admin card/grid layout fix
+---
 
-- **File**: `Static/css/styles.css`
-- **Fix**: `.admin-container` grid — make pending and gallery sections span full width
-- **Public gallery**: `.gallery-grid` CSS is already correct (`repeat(auto-fill, minmax(300px, 1fr))`); verify no parent constrains width
-- **Admin gallery cards**: Reuse `.pending-card` component with additional action button row
+## Part 1: Track A — Mobile Web (FastAPI + Jinja2)
+
+### 1.1 Mobile-Responsive Layout
+
+Update `Static/css/styles.css`:
+- Add mobile breakpoint (`max-width: 600px`) styles
+- Touch targets >= 44x44px
+- Single-column layouts for all views on mobile
+
+### 1.2 Dark Mode
+
+Add `.az-light` / `.az-dark` class scoping:
+- Carbon (#121212) <-> Parchment (#F9F7F2) swap
+- CSS custom properties for theme colors
+- JS toggle that sets class on `<html>` and persists to localStorage
+- `prefers-color-scheme` media query as default
+
+### 1.3 Admin Bottom Tab Bar (admin templates only)
+
+**Scoped to admin views** — the public gallery does NOT get a bottom tab bar.
+
+- Bottom fixed navigation bar on mobile for admin templates
+- 5 tabs: Queue, Review, Capture, Gallery, Settings
+- Tab icons (inline SVG)
+- Active tab highlighting
+- Smooth tab transitions
+- Hidden on desktop (admin already has top nav tabs)
+
+### 1.4 Review Queue Enhancements (reviewAddedFiles.html)
+
+The admin page already has segmented Dashboard/Settings tabs, search bar, gallery/pending sections. Enhancements:
+
+- Status filter segmented control: All / Pending / Approved / Hidden
+- Tag-based filtering in search
+- Swipe-to-approve/hide on mobile (touch gesture JS)
+- Card layout responsive improvements
+
+### 1.5 Swipe Deck View (new template section or JS mode)
+
+- Card stack UI for reviewing pending artworks
+- Swipe right = approve, swipe left = hide
+- Animated card transitions (CSS + touch event JS)
+- Fallback to button-based approve/hide on non-touch devices
+
+### 1.6 Artwork Detail Enhancements (artwork_detail.html)
+
+- Display all v2 fields (caption, tags, artist, copyright, collection)
+- Card-to-card navigation (prev/next arrows)
+- Per-field AI regeneration buttons (calls extended `/admin/ai/regenerate` with `fields` param)
+- Mobile-responsive single-column layout (replace inline 2-column grid)
+- Remove inline styles, use CSS classes
+
+### 1.7 Capture Flow (new template section)
+
+- Camera input via `<input type="file" accept="image/*" capture="environment">`
+- Upload preview with AI metadata generation
+- Progress indicator during AI processing
+- Form to edit generated metadata before save
+
+### 1.8 Settings View Enhancement
+
+- Dark mode toggle (new)
+- Existing AI config (toggle, model, temperature, tokens) already in place
+
+---
+
+## Part 2: Track B — SwiftUI Specification
+
+> **Important**: Authored on Linux. The SwiftUI code is a specification — cannot be compiled or tested here. Deliverables are source files in an `ArtazzenMobile/` directory with a Swift Package structure.
+
+### 2.1 Project Structure
+
+```
+ArtazzenMobile/
+├── Package.swift              # iOS 17+, SwiftUI
+├── Sources/
+│   ├── ArtazzenMobileApp.swift
+│   ├── Models/
+│   │   ├── Artwork.swift      # Codable struct matching v2 schema
+│   │   ├── Collection.swift
+│   │   └── AIConfig.swift
+│   ├── Services/
+│   │   └── ArtazzenAPI.swift  # URLSession client for FastAPI backend
+│   ├── Views/
+│   │   ├── MainTabView.swift  # 5-tab TabView
+│   │   ├── Queue/
+│   │   │   ├── QueueView.swift
+│   │   │   └── QueueCard.swift
+│   │   ├── Review/
+│   │   │   ├── SwipeDeckView.swift
+│   │   │   └── ReviewCard.swift
+│   │   ├── Capture/
+│   │   │   ├── CaptureView.swift
+│   │   │   └── MetadataEditor.swift
+│   │   ├── Gallery/
+│   │   │   ├── GalleryView.swift
+│   │   │   ├── GalleryGrid.swift
+│   │   │   └── ArtworkDetailView.swift
+│   │   └── Settings/
+│   │       └── SettingsView.swift
+│   └── Components/
+│       ├── ArtworkCard.swift
+│       ├── TagPill.swift
+│       ├── AIFieldEditor.swift
+│       └── StatusBadge.swift
+└── Tests/
+    └── ArtazzenMobileTests/
+        └── ArtworkTests.swift  # Codable decode/encode tests
+```
+
+### 2.2 Data Models
+
+```swift
+struct Artwork: Codable, Identifiable {
+    var id: String { filename }
+    let filename: String
+    var title: String
+    var description: String
+    var caption: String
+    var tags: [String]
+    var artist: String
+    var copyright: String
+    var collection: String
+    var status: ArtworkStatus
+    var aiGenerated: Bool
+    var aiFields: [AIField]
+    let detectedAt: Double
+
+    enum ArtworkStatus: String, Codable {
+        case pending, approved, hidden
+    }
+
+    enum AIField: String, Codable {
+        case title, caption, description, tags
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case filename, title, description, caption, tags
+        case artist, copyright, collection, status
+        case aiGenerated = "ai_generated"
+        case aiFields = "ai_fields"
+        case detectedAt = "detected_at"
+    }
+}
+```
+
+### 2.3 API Client
+
+```swift
+actor ArtazzenAPI {
+    let baseURL: URL
+    let credentials: (username: String, password: String)
+
+    func fetchPending() async throws -> [Artwork]
+    func saveMetadata(_ artwork: Artwork) async throws
+    func regenerateFields(image: String, fields: [Artwork.AIField]) async throws -> Artwork
+    func upload(imageData: Data, filename: String) async throws
+    func unapprove(_ name: String) async throws
+    func delete(_ name: String) async throws
+    func fetchCollections() async throws -> [String]
+}
+```
+
+### 2.4 Key View Specs
+
+- **MainTabView**: TabView with 5 tabs — Queue (list.bullet), Review (rectangle.stack), Capture (camera), Gallery (photo.on.rectangle), Settings (gear)
+- **SwipeDeckView**: ZStack of ReviewCards with DragGesture. Threshold 120pt. Right = approve, left = hide. Spring animation on snap-back, ease-out on dismiss.
+- **CaptureView**: PhotosPicker + camera source. Preview → AI metadata → edit → save.
+- **ArtworkDetailView**: NavigationStack with toolbar. Large image, scrollable metadata form. Per-field regenerate buttons. Tags as editable pill collection.
+- **GalleryView**: LazyVGrid adaptive columns (min 160pt). Search bar. Collection picker via Menu. Status badge overlays.
+
+### 2.5 Design Tokens (SwiftUI)
+
+```swift
+extension Color {
+    static let azCarbon = Color(hex: "#121212")
+    static let azParchment = Color(hex: "#F9F7F2")
+    static let azTeal = Color(hex: "#0D9488")
+    static let azOrange = Color(hex: "#F97316")
+    static let azViolet = Color(hex: "#8B5CF6")
+}
+
+extension Font {
+    static let azDisplay = Font.custom("ClashGrotesk-Bold", size: 28)
+    static let azBody = Font.custom("InstrumentSans-Regular", size: 16)
+    static let azMono = Font.custom("JetBrainsMono-Regular", size: 13)
+}
+```
+
+---
+
+## Implementation Order
+
+1. **Schema v2 + migration** (0.1, 0.2) — fixes existing validation failures, both tracks need this
+2. **API changes** (0.3, 0.4) — both tracks consume these endpoints
+3. **Track A: Mobile web** (Part 1) — extends existing app
+4. **Track B: SwiftUI spec** (Part 2) — standalone deliverable
+
+## Constraints
+
+- All Python code stays in `main.py` per project rules
+- SwiftUI specs are **authored, not verified** (Linux — no Xcode)
+- Feature branch from `dev`, PR targeting `dev`
+- Workflows capped at <5 agents
+- `Static/` capital-S preserved everywhere
 
 ## Files Modified
 
-| File                              | Changes                                                                                                                   |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `main.py`                         | Filter gallery, new routes (settings, unapprove, soft-delete), gallery data to admin, env var for title, watcher race fix |
-| `templates/reviewAddedFiles.html` | Gallery section, search bar, nav tabs, remove inline AI settings, pretext, interaction states                             |
-| `templates/admin_settings.html`   | New — AI config form (moved from dashboard)                                                                               |
-| `templates/index.html`            | Add intro/pretext paragraph, use GALLERY_TITLE                                                                            |
-| `Static/css/styles.css`           | Admin grid fix, search bar styles, nav tab styles, card action styles, transition animations                              |
-| `ImageSidecar.schema.json`        | Add `status` enum field, update required fields                                                                           |
-| `scripts/migrate_status.py`       | New — migrate sidecars from `reviewed` boolean to `status` enum                                                           |
-| `.env.example`                    | Add GALLERY_TITLE                                                                                                         |
-| `tests/test_main.py`              | New tests for all new endpoints                                                                                           |
-
-## Test Plan
-
-### Automated (pytest)
-
-- `test_gallery_shows_only_reviewed` — public `/` excludes `reviewed: false`
-- `test_admin_shows_pending_and_gallery` — `/admin` returns both sections
-- `test_delete_requires_auth` — unauthenticated POST returns 401
-- `test_delete_removes_image_to_trash` — happy path, verify `.trash/` contents
-- `test_delete_path_traversal` — `../` payloads rejected
-- `test_delete_nonexistent_returns_404`
-- `test_unapprove_requires_auth` — unauthenticated POST returns 401
-- `test_unapprove_sets_reviewed_false` — verify sidecar after
-- `test_unapprove_preserves_metadata` — title/description/ai_details survive
-- `test_settings_page_loads` — `/admin/settings` returns 200
-- `test_settings_page_requires_auth`
-
-### Manual verification
-
-1. Upload images, verify they appear in admin pending (not public gallery)
-2. Review/approve images, verify they move to admin gallery section and appear on public gallery
-3. Un-approve from gallery, verify return to pending with metadata intact
-4. Soft-delete from gallery, verify moved to `.trash/`
-5. Search filter across both sections — matches and "no matches" state
-6. Settings page loads, saves, resets AI config
-7. Card grid layout responsive at 1200px, 900px, 600px breakpoints
-8. Nav tabs highlight active page
-9. All existing functionality preserved (upload, import, AI regen)
-
-<!-- AUTONOMOUS DECISION LOG -->
-
-## Decision Audit Trail
-
-| #   | Phase  | Decision                                                   | Classification   | Principle       | Rationale                                          | Rejected                 |
-| --- | ------ | ---------------------------------------------------------- | ---------------- | --------------- | -------------------------------------------------- | ------------------------ |
-| 1   | CEO    | Add migration to bulk-approve existing images              | Mechanical       | P1 completeness | Without it, gallery drops to ~10 images            | Ship without migration   |
-| 2   | CEO    | Ship reviewed-only filter as separate Phase A PR           | Mechanical       | P6 action       | Content-control bug shouldn't wait for features    | Bundle everything        |
-| 3   | CEO    | Status enum vs reviewed boolean                            | TASTE → OVERRIDE | P1 completeness | User chose status enum (pending/approved/hidden)   | Reviewed boolean         |
-| 4   | CEO    | Soft-delete instead of hard delete                         | Mechanical       | P1 completeness | Irreversible on irreplaceable art                  | os.remove                |
-| 5   | CEO    | Add pagination                                             | Mechanical       | P1 completeness | 184 images, growing                                | Client-only filter       |
-| 6   | CEO    | Drop settings extraction → keep in plan but lower priority | Mechanical       | P3 pragmatic    | Cleans up admin, low effort                        | Remove entirely          |
-| 7   | CEO    | Update gallery title from placeholder                      | Mechanical       | P1 completeness | Live placeholder in production                     | Leave as-is              |
-| 8   | Design | Specify admin section order                                | Mechanical       | P5 explicit     | Search > Gallery > Pending > Upload                | Let implementer decide   |
-| 9   | Design | Add interaction states for new actions                     | Mechanical       | P1 completeness | Delete/un-approve need feedback                    | Skip states              |
-| 10  | Design | Gallery first for returning curators                       | TASTE → OVERRIDE | P5 explicit     | User chose Upload-first (initial population phase) | Gallery first            |
-| 11  | Design | Reuse .pending-card for gallery cards                      | Mechanical       | P5 explicit     | Existing pattern, consistent                       | New component            |
-| 12  | Design | Fix admin grid to full-width sections                      | Mechanical       | P5 explicit     | Current 1fr/2fr squashes content                   | Keep current grid        |
-| 13  | Design | Define admin nav as tab bar                                | Mechanical       | P5 explicit     | Dashboard + Settings need navigation               | No nav                   |
-| 14  | Design | Reference design system tokens                             | Mechanical       | P1 completeness | Techno-Botanical consistency                       | Ad-hoc styles            |
-| 15  | Eng    | Delete must use _resolve_image_path                        | Mechanical       | P5 explicit     | Path traversal protection                          | Direct path construction |
-| 16  | Eng    | Handle FileNotFoundError in watcher                        | Mechanical       | P1 completeness | Race condition fix                                 | Ignore                   |
-| 17  | Eng    | Un-approve preserves AI metadata                           | Mechanical       | P5 explicit     | Document the behavior                              | Clear metadata           |
-| 18  | Eng    | Auth on all new endpoints                                  | Mechanical       | P1 completeness | Every admin route uses Depends                     | Skip auth                |
-| 19  | Eng    | Soft-delete aligns with CEO finding                        | Mechanical       | P1 completeness | .trash/ subdirectory                               | Hard delete              |
-| 20  | Eng    | Add 11 pytest tests                                        | Mechanical       | P1 completeness | New endpoints need coverage                        | Manual only              |
-| 21  | Eng    | Cache gallery list (deferred)                              | Mechanical       | P3 pragmatic    | Defer until measured                               | Implement now            |
-
-## GSTACK REVIEW REPORT
-
-**Reviewed by**: /autoplan (CEO + Design + Eng, Claude subagent-only — Codex unavailable)
-**Plan status**: APPROVED — 21 decisions applied, 2 taste decisions overridden by user (status enum + upload-first)
-**Phases completed**: CEO (7 findings), Design (7 findings), Eng (7 findings), DX (skipped — no developer scope)
+| File | Change |
+|------|--------|
+| `ImageSidecar.schema.json` | Add v2 fields, keep `author` deprecated, fix validation |
+| `main.py` | Extended endpoints, new `/admin/api/collections`, expanded AI prompt+parser, `ai_fields` tracking |
+| `manage_sidecars.py` | v2 validation support |
+| `Static/css/styles.css` | Mobile responsive, dark mode, bottom tab bar (admin only), new components |
+| `templates/reviewAddedFiles.html` | Status filter, swipe deck, mobile tab bar, responsive enhancements |
+| `templates/artwork_detail.html` | v2 fields, per-field regen, mobile responsive, remove inline styles |
+| `templates/index.html` | Mobile responsive gallery grid |
+| `templates/previewImageText.html` | v2 fields in review form |
+| `scripts/migrate_v2.py` | New — sidecar migration script |
+| `ArtazzenMobile/` | New — SwiftUI package (Track B) |

--- a/PLAN.md
+++ b/PLAN.md
@@ -31,15 +31,15 @@ Both tracks share a backend contract: schema v2, updated API endpoints, and side
 
 Update the existing schema. New fields (all with defaults for backwards compat):
 
-| Field | Type | Default | Notes |
-|-------|------|---------|-------|
-| `caption` | string | `""` | Already in sidecars, not in schema |
-| `tags` | string[] | `[]` | Already in sidecars, not in schema |
-| `artist` | string | `""` | New canonical name (replaces `author`) |
-| `copyright` | string | `""` | Already in sidecars, not in schema |
-| `collection` | string | `""` | New field |
-| `ai_fields` | string[] (enum: title/caption/description/tags) | `[]` | Tracks which fields AI generated |
-| `author` | string | `""` | **Deprecated** — kept for backwards compat like `reviewed` |
+| Field        | Type                                            | Default | Notes                                                      |
+| ------------ | ----------------------------------------------- | ------- | ---------------------------------------------------------- |
+| `caption`    | string                                          | `""`    | Already in sidecars, not in schema                         |
+| `tags`       | string[]                                        | `[]`    | Already in sidecars, not in schema                         |
+| `artist`     | string                                          | `""`    | New canonical name (replaces `author`)                     |
+| `copyright`  | string                                          | `""`    | Already in sidecars, not in schema                         |
+| `collection` | string                                          | `""`    | New field                                                  |
+| `ai_fields`  | string[] (enum: title/caption/description/tags) | `[]`    | Tracks which fields AI generated                           |
+| `author`     | string                                          | `""`    | **Deprecated** — kept for backwards compat like `reviewed` |
 
 Keep `reviewed` (deprecated). Keep `additionalProperties: false`. Keep `author` as deprecated (do NOT remove — production sidecars on Railway volume would fail validation between deploy and migration run if the field is removed from schema before migration runs).
 
@@ -48,6 +48,7 @@ Keep `reviewed` (deprecated). Keep `additionalProperties: false`. Keep `author` 
 ### 0.2 Sidecar Migration Script
 
 `scripts/migrate_v2.py`:
+
 1. For each `.json` sidecar in IMAGES_DIR:
    - Add missing v2 fields with defaults
    - Copy `author` → `artist` if `author` present and `artist` empty
@@ -109,6 +110,7 @@ All templates that display metadata need the new fields in their context dict. U
 ### 1.1 Mobile-Responsive Layout
 
 Update `Static/css/styles.css`:
+
 - Add mobile breakpoint (`max-width: 600px`) styles
 - Touch targets >= 44x44px
 - Single-column layouts for all views on mobile
@@ -116,6 +118,7 @@ Update `Static/css/styles.css`:
 ### 1.2 Dark Mode
 
 Add `.az-light` / `.az-dark` class scoping:
+
 - Carbon (#121212) <-> Parchment (#F9F7F2) swap
 - CSS custom properties for theme colors
 - JS toggle that sets class on `<html>` and persists to localStorage
@@ -312,15 +315,15 @@ extension Font {
 
 ## Files Modified
 
-| File | Change |
-|------|--------|
-| `ImageSidecar.schema.json` | Add v2 fields, keep `author` deprecated, fix validation |
-| `main.py` | Extended endpoints, new `/admin/api/collections`, expanded AI prompt+parser, `ai_fields` tracking |
-| `manage_sidecars.py` | v2 validation support |
-| `Static/css/styles.css` | Mobile responsive, dark mode, bottom tab bar (admin only), new components |
-| `templates/reviewAddedFiles.html` | Status filter, swipe deck, mobile tab bar, responsive enhancements |
-| `templates/artwork_detail.html` | v2 fields, per-field regen, mobile responsive, remove inline styles |
-| `templates/index.html` | Mobile responsive gallery grid |
-| `templates/previewImageText.html` | v2 fields in review form |
-| `scripts/migrate_v2.py` | New — sidecar migration script |
-| `ArtazzenMobile/` | New — SwiftUI package (Track B) |
+| File                              | Change                                                                                            |
+| --------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `ImageSidecar.schema.json`        | Add v2 fields, keep `author` deprecated, fix validation                                           |
+| `main.py`                         | Extended endpoints, new `/admin/api/collections`, expanded AI prompt+parser, `ai_fields` tracking |
+| `manage_sidecars.py`              | v2 validation support                                                                             |
+| `Static/css/styles.css`           | Mobile responsive, dark mode, bottom tab bar (admin only), new components                         |
+| `templates/reviewAddedFiles.html` | Status filter, swipe deck, mobile tab bar, responsive enhancements                                |
+| `templates/artwork_detail.html`   | v2 fields, per-field regen, mobile responsive, remove inline styles                               |
+| `templates/index.html`            | Mobile responsive gallery grid                                                                    |
+| `templates/previewImageText.html` | v2 fields in review form                                                                          |
+| `scripts/migrate_v2.py`           | New — sidecar migration script                                                                    |
+| `ArtazzenMobile/`                 | New — SwiftUI package (Track B)                                                                   |

--- a/Static/css/styles.css
+++ b/Static/css/styles.css
@@ -713,6 +713,17 @@ footer {
     color: var(--text-muted);
 }
 
+.field-with-regen {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+}
+.field-with-regen input,
+.field-with-regen textarea {
+    flex: 1;
+    min-width: 0;
+}
+
 /* Per-field AI regenerate button */
 .field-regen-btn {
     font-family: var(--font-mono);

--- a/Static/css/styles.css
+++ b/Static/css/styles.css
@@ -643,7 +643,6 @@ footer {
     .path-input-row {
         flex-direction: column;
     }
-    .admin-page body,
     body.admin-page {
         padding-bottom: 72px;
     }

--- a/Static/css/styles.css
+++ b/Static/css/styles.css
@@ -30,13 +30,29 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not(.az-light) {
         --text-main: var(--parchment);
         --text-muted: #999999;
         --bg-main: var(--carbon);
         --bg-panel: rgba(255, 255, 255, 0.03);
         --border-color: rgba(255, 255, 255, 0.1);
     }
+}
+
+:root.az-dark {
+    --text-main: var(--parchment);
+    --text-muted: #999999;
+    --bg-main: var(--carbon);
+    --bg-panel: rgba(255, 255, 255, 0.03);
+    --border-color: rgba(255, 255, 255, 0.1);
+}
+
+:root.az-light {
+    --text-main: var(--carbon);
+    --text-muted: #666666;
+    --bg-main: var(--parchment);
+    --bg-panel: rgba(0, 0, 0, 0.02);
+    --border-color: rgba(0, 0, 0, 0.1);
 }
 
 /* Base Styles */
@@ -579,4 +595,239 @@ footer {
     .artwork-item:nth-child(even) {
         margin-top: 0;
     }
+    header {
+        padding: 2rem 1rem;
+    }
+    header h1 {
+        font-size: 2rem;
+    }
+    main {
+        padding: 1rem;
+    }
+    .admin-page header {
+        padding: 1.5rem 1rem;
+    }
+    .admin-page h1 {
+        font-size: 1.75rem;
+    }
+    .admin-panel {
+        padding: 1rem;
+    }
+    .admin-grid {
+        grid-template-columns: 1fr;
+    }
+    .panel-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .panel-actions .button,
+    .panel-actions .checkbox {
+        min-height: 44px;
+        justify-content: center;
+    }
+    .admin-card-actions .button {
+        min-height: 44px;
+        padding: 0.5rem 1rem;
+        font-size: 0.75rem;
+    }
+    .admin-tabs {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .admin-tab {
+        min-height: 44px;
+    }
+    .button {
+        min-height: 44px;
+    }
+    .path-input-row {
+        flex-direction: column;
+    }
+    .admin-page body,
+    body.admin-page {
+        padding-bottom: 72px;
+    }
+}
+
+/* Admin Bottom Tab Bar — mobile only */
+.admin-bottom-tabs {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    .admin-bottom-tabs {
+        display: flex;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background: var(--bg-main);
+        border-top: 1px solid var(--border-color);
+        z-index: 900;
+        padding: 0;
+        justify-content: space-around;
+    }
+    .admin-bottom-tab {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 8px 4px;
+        min-height: 56px;
+        min-width: 56px;
+        border: none;
+        background: transparent;
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+        font-size: 0.6rem;
+        text-transform: uppercase;
+        cursor: pointer;
+        text-decoration: none;
+        transition: color 0.2s ease;
+    }
+    .admin-bottom-tab.active,
+    .admin-bottom-tab:hover {
+        color: var(--accent-teal);
+    }
+    .admin-bottom-tab svg {
+        width: 22px;
+        height: 22px;
+        margin-bottom: 2px;
+    }
+}
+
+/* Tag pills */
+.tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+}
+
+.tag-pill {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    padding: 0.2rem 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--bg-panel);
+    color: var(--text-muted);
+}
+
+/* Per-field AI regenerate button */
+.field-regen-btn {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    padding: 0.2rem 0.5rem;
+    border: 1px solid var(--accent-violet);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--accent-violet);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.field-regen-btn:hover {
+    background: var(--accent-violet);
+    color: white;
+}
+
+/* Status filter segmented control */
+.status-filter {
+    display: flex;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.status-filter button {
+    font-family: var(--font-heading);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.03em;
+    padding: 0.5rem 1rem;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-height: 44px;
+}
+
+.status-filter button.active {
+    background: var(--text-main);
+    color: var(--bg-main);
+}
+
+.status-filter button:not(:last-child) {
+    border-right: 1px solid var(--border-color);
+}
+
+/* Artwork detail responsive */
+.artwork-detail-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4rem;
+    align-items: start;
+}
+
+@media (max-width: 900px) {
+    .artwork-detail-grid {
+        grid-template-columns: 1fr;
+        gap: 2rem;
+    }
+}
+
+.artwork-detail-grid img {
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius-sm);
+    filter: grayscale(10%);
+    transition: filter 0.5s ease;
+}
+
+.artwork-detail-grid img:hover {
+    filter: grayscale(0%);
+}
+
+.artwork-meta-label {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    opacity: 0.6;
+    margin-bottom: 0.25rem;
+}
+
+.artwork-meta-value {
+    font-size: 1rem;
+    line-height: 1.6;
+    margin-bottom: 1.5rem;
+}
+
+/* Dark mode toggle */
+.dark-mode-toggle {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-main);
+    cursor: pointer;
+    min-height: 44px;
+}
+
+/* Screen reader only */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
 }

--- a/main.py
+++ b/main.py
@@ -1143,7 +1143,7 @@ async def list_collections(_: None = Depends(_verify_admin)) -> JSONResponse:
             json_path = IMAGES_DIR / name
             try:
                 data = json.loads(json_path.read_text(encoding="utf-8"))
-                val = data.get("collection", "").strip()
+                val = str(data.get("collection") or "").strip()
                 if val:
                     collections.add(val)
             except (json.JSONDecodeError, OSError):

--- a/main.py
+++ b/main.py
@@ -395,27 +395,33 @@ def _extract_exif_metadata(image_path: Path) -> dict[str, str]:
 def _build_openai_prompt(
     image_path: Path,
     metadata: dict[str, Any],
-    needs_title: bool,
-    needs_description: bool,
+    needed_fields: list[str],
 ) -> str:
     """Create a deterministic prompt for the OpenAI metadata request."""
     hints: list[str] = []
-    if metadata.get("title"):
-        hints.append(f"Existing title: {metadata['title']}")
-    if metadata.get("description"):
-        hints.append(f"Existing description: {metadata['description']}")
+    for key in ("title", "description", "caption", "artist"):
+        if metadata.get(key):
+            hints.append(f"Existing {key}: {metadata[key]}")
+    if metadata.get("tags"):
+        hints.append(f"Existing tags: {', '.join(metadata['tags'])}")
     hint_text = "\n".join(hints) if hints else "No reliable text metadata was detected."
-    requested_parts: list[str] = []
-    if needs_title:
-        requested_parts.append("a short but descriptive title (<= 80 characters)")
-    if needs_description:
-        requested_parts.append("an engaging description (<= 400 characters)")
+
+    field_descriptions: dict[str, str] = {
+        "title": "a short but descriptive title (<= 80 characters)",
+        "description": "an engaging description (<= 400 characters)",
+        "caption": "a concise gallery caption (<= 160 characters)",
+        "tags": "3-8 descriptive tags for categorization",
+    }
+    requested_parts = [field_descriptions[f] for f in needed_fields if f in field_descriptions]
     requested = " and ".join(requested_parts)
+
+    field_keys = ", ".join(f'"{f}"' for f in needed_fields)
     return textwrap.dedent(f"""
         You are assisting with cataloging artwork. Analyze the provided image
         named '{image_path.name}'. {hint_text}
-        Generate {requested}. Respond with JSON that contains the keys "title" and "description"
-        with concise English text suitable for a public art gallery. Avoid mentioning that information
+        Generate {requested}. Respond with JSON containing the keys {field_keys}
+        with concise English text suitable for a public art gallery. For tags,
+        return an array of lowercase strings. Avoid mentioning that information
         is guessed or unavailable.
         """).strip()
 
@@ -463,13 +469,12 @@ def _get_openai_api_key() -> str | None:
 def _request_openai_metadata(
     image_path: Path,
     metadata: dict[str, Any],
-    needs_title: bool,
-    needs_description: bool,
+    needed_fields: list[str],
 ) -> dict[str, Any]:
     """Request metadata from OpenAI and return the response payload."""
     ai_cfg = _get_ai_config()
     model = ai_cfg["model"]
-    prompt = _build_openai_prompt(image_path, metadata, needs_title, needs_description)
+    prompt = _build_openai_prompt(image_path, metadata, needed_fields)
     details: dict[str, Any] = {
         "provider": "openai",
         "model": model,
@@ -530,10 +535,10 @@ def _request_openai_metadata(
                 "schema": {
                     "type": "object",
                     "properties": {
-                        "title": {"type": "string"},
-                        "description": {"type": "string"},
+                        f: ({"type": "array", "items": {"type": "string"}} if f == "tags" else {"type": "string"})
+                        for f in needed_fields
                     },
-                    "required": ["title", "description"],
+                    "required": sorted(needed_fields),
                     "additionalProperties": False,
                 },
             }
@@ -640,22 +645,44 @@ def _request_openai_metadata(
         "usage": payload.get("usage", {}),
     }
 
-    title = str(parsed.get("title", "")).strip()
-    description = str(parsed.get("description", "")).strip()
-    return {"title": title, "description": description, "details": details}
+    result: dict[str, Any] = {"details": details}
+    for field in needed_fields:
+        val = parsed.get(field)
+        if field == "tags" and isinstance(val, list):
+            result[field] = [str(t).strip() for t in val if str(t).strip()]
+        elif val is not None:
+            result[field] = str(val).strip()
+        else:
+            result[field] = "" if field != "tags" else []
+    return result
 
 
 def _populate_missing_metadata(
-    image_path: Path, metadata: dict[str, Any]
+    image_path: Path,
+    metadata: dict[str, Any],
+    only_fields: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Fill missing metadata using OpenAI when configured."""
-    title_value = (metadata.get("title") or "").strip()
-    description_value = (metadata.get("description") or "").strip()
-    needs_title = title_value == ""
-    needs_description = description_value == ""
-    if not (needs_title or needs_description):
+    """Fill missing metadata using OpenAI when configured.
+
+    If only_fields is provided, only regenerate those specific fields.
+    Otherwise, regenerate any empty AI-eligible field.
+    """
+    ai_eligible = ["title", "description", "caption", "tags"]
+
+    if only_fields is not None:
+        needed_fields = [f for f in only_fields if f in ai_eligible]
+    else:
+        needed_fields = []
+        for field in ai_eligible:
+            val = metadata.get(field)
+            if field == "tags":
+                if not val:
+                    needed_fields.append(field)
+            elif not (val or "").strip():
+                needed_fields.append(field)
+
+    if not needed_fields:
         return metadata
-    # Respect runtime toggle
     if not _get_ai_config().get("enabled", True):
         return metadata
 
@@ -667,17 +694,21 @@ def _populate_missing_metadata(
     if not _get_openai_api_key() and ai_details.get("status") == "skipped_no_api_key":
         return metadata
 
-    result = _request_openai_metadata(
-        image_path, metadata, needs_title, needs_description
-    )
+    result = _request_openai_metadata(image_path, metadata, needed_fields)
     details = result.get("details", {})
     metadata["ai_details"] = details
 
     if details.get("status") == "success":
-        if needs_title and result.get("title"):
-            metadata["title"] = result["title"]
-        if needs_description and result.get("description"):
-            metadata["description"] = result["description"]
+        existing_ai_fields = set(metadata.get("ai_fields", []))
+        for field in needed_fields:
+            val = result.get(field)
+            if field == "tags" and isinstance(val, list) and val:
+                metadata["tags"] = val
+                existing_ai_fields.add("tags")
+            elif isinstance(val, str) and val:
+                metadata[field] = val
+                existing_ai_fields.add(field)
+        metadata["ai_fields"] = sorted(existing_ai_fields)
         metadata["ai_generated"] = True
     else:
         metadata.setdefault("ai_generated", False)
@@ -1095,6 +1126,27 @@ async def api_new_files(
     return JSONResponse({"pending": pending, "gallery": gallery})
 
 
+@app.get("/admin/api/collections", response_class=JSONResponse)
+async def list_collections(_: None = Depends(_verify_admin)) -> JSONResponse:
+    """Return distinct collection values from all sidecars."""
+    collections: set[str] = set()
+    try:
+        for name in os.listdir(IMAGES_DIR):
+            if not name.lower().endswith(".json"):
+                continue
+            json_path = IMAGES_DIR / name
+            try:
+                data = json.loads(json_path.read_text(encoding="utf-8"))
+                val = data.get("collection", "").strip()
+                if val:
+                    collections.add(val)
+            except (json.JSONDecodeError, OSError):
+                continue
+    except OSError:
+        pass
+    return JSONResponse({"collections": sorted(collections)})
+
+
 @app.get("/admin/config", response_class=JSONResponse)
 async def get_admin_config(_: None = Depends(_verify_admin)) -> JSONResponse:
     cfg = _get_ai_config()
@@ -1161,6 +1213,14 @@ async def regenerate_ai_metadata(
         body = {}
     images = body.get("images") or []
     force = bool(body.get("force", False))
+    fields: list[str] | None = body.get("fields")
+    if isinstance(fields, list):
+        fields = [f for f in fields if f in ("title", "description", "caption", "tags")]
+        if not fields:
+            fields = None
+    else:
+        fields = None
+
     if not isinstance(images, list) or not images:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="No images provided"
@@ -1180,9 +1240,13 @@ async def regenerate_ai_metadata(
         try:
             meta = _load_metadata(path)
             if force:
-                meta["title"] = ""
-                meta["description"] = ""
-            meta = _populate_missing_metadata(path, meta)
+                blank_fields = fields or ["title", "description", "caption", "tags"]
+                for f in blank_fields:
+                    if f == "tags":
+                        meta["tags"] = []
+                    else:
+                        meta[f] = ""
+            meta = _populate_missing_metadata(path, meta, only_fields=fields)
             _write_sidecar(path, meta)
             updated.append({"name": fname, "metadata": meta})
         except Exception:
@@ -1339,6 +1403,11 @@ async def update_image_metadata(
     image_name: str,
     title: str = Form(""),
     description: str = Form(""),
+    caption: str = Form(""),
+    tags: str = Form(""),
+    artist: str = Form(""),
+    copyright_info: str = Form("", alias="copyright"),
+    collection: str = Form(""),
     action: str = Form("save"),
     pending_dependency: list[dict[str, Any]] = Depends(get_pending_files),
     _: None = Depends(_verify_admin),
@@ -1361,11 +1430,16 @@ async def update_image_metadata(
             status_code=status.HTTP_404_NOT_FOUND, detail="Image not found"
         )
 
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
     clean_metadata = {
         "title": title.strip() or image_path.stem,
         "description": description.strip(),
+        "caption": caption.strip(),
+        "tags": tag_list,
+        "artist": artist.strip(),
+        "copyright": copyright_info.strip(),
+        "collection": collection.strip(),
     }
-    # Merge with existing sidecar and mark as approved
     existing = _load_metadata(image_path)
     existing.update(clean_metadata)
     existing["status"] = "approved"
@@ -1441,13 +1515,33 @@ async def artwork_detail(request: Request, image_filename: str):
     artwork_data = {
         "title": metadata.get("title", "Artwork"),
         "description": metadata.get("description", ""),
+        "caption": metadata.get("caption", ""),
+        "tags": metadata.get("tags", []),
+        "artist": metadata.get("artist", ""),
+        "copyright": metadata.get("copyright", ""),
+        "collection": metadata.get("collection", ""),
         "image_url": image_url,
     }
+
+    gallery = get_artwork_files(status_filter="approved")
+    filenames = [item["name"] for item in gallery]
+    prev_artwork = None
+    next_artwork = None
+    if filename in filenames:
+        idx = filenames.index(filename)
+        if idx > 0:
+            prev_artwork = filenames[idx - 1]
+        if idx < len(filenames) - 1:
+            next_artwork = filenames[idx + 1]
 
     return templates.TemplateResponse(
         request,
         "artwork_detail.html",
-        {"artwork": artwork_data},
+        {
+            "artwork": artwork_data,
+            "prev_artwork": prev_artwork,
+            "next_artwork": next_artwork,
+        },
     )
 
 

--- a/main.py
+++ b/main.py
@@ -402,8 +402,12 @@ def _build_openai_prompt(
     for key in ("title", "description", "caption", "artist"):
         if metadata.get(key):
             hints.append(f"Existing {key}: {metadata[key]}")
-    if metadata.get("tags"):
-        hints.append(f"Existing tags: {', '.join(metadata['tags'])}")
+    tags = metadata.get("tags")
+    if tags:
+        if isinstance(tags, list):
+            hints.append(f"Existing tags: {', '.join(str(t) for t in tags)}")
+        elif isinstance(tags, str):
+            hints.append(f"Existing tags: {tags}")
     hint_text = "\n".join(hints) if hints else "No reliable text metadata was detected."
 
     field_descriptions: dict[str, str] = {
@@ -1237,7 +1241,10 @@ async def regenerate_ai_metadata(
     if isinstance(fields, list):
         fields = [f for f in fields if f in ("title", "description", "caption", "tags")]
         if not fields:
-            fields = None
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No supported fields provided. Use: title, description, caption, tags",
+            )
     else:
         fields = None
 

--- a/main.py
+++ b/main.py
@@ -1239,7 +1239,11 @@ async def regenerate_ai_metadata(
     force = bool(body.get("force", False))
     fields: list[str] | None = body.get("fields")
     if isinstance(fields, list):
-        fields = [f for f in fields if f in ("title", "description", "caption", "tags")]
+        fields = list(
+            dict.fromkeys(
+                f for f in fields if f in ("title", "description", "caption", "tags")
+            )
+        )
         if not fields:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/main.py
+++ b/main.py
@@ -654,8 +654,13 @@ def _request_openai_metadata(
     result: dict[str, Any] = {"details": details}
     for field in needed_fields:
         val = parsed.get(field)
-        if field == "tags" and isinstance(val, list):
-            result[field] = [str(t).strip() for t in val if str(t).strip()]
+        if field == "tags":
+            if isinstance(val, list):
+                result[field] = [str(t).strip() for t in val if str(t).strip()]
+            elif isinstance(val, str) and val.strip():
+                result[field] = [t.strip() for t in val.split(",") if t.strip()]
+            else:
+                result[field] = []
         elif val is not None:
             result[field] = str(val).strip()
         else:
@@ -1447,8 +1452,12 @@ async def update_image_metadata(
         "collection": collection.strip(),
     }
     existing = _load_metadata(image_path)
+    prior_ai = set(existing.get("ai_fields", []))
     existing.update(clean_metadata)
     existing["status"] = "approved"
+    if prior_ai:
+        edited = {f for f in ("title", "description", "caption", "tags") if f in clean_metadata}
+        existing["ai_fields"] = sorted(prior_ai - edited)
     _write_sidecar(image_path, existing)
 
     return RedirectResponse(

--- a/main.py
+++ b/main.py
@@ -412,7 +412,9 @@ def _build_openai_prompt(
         "caption": "a concise gallery caption (<= 160 characters)",
         "tags": "3-8 descriptive tags for categorization",
     }
-    requested_parts = [field_descriptions[f] for f in needed_fields if f in field_descriptions]
+    requested_parts = [
+        field_descriptions[f] for f in needed_fields if f in field_descriptions
+    ]
     requested = " and ".join(requested_parts)
 
     field_keys = ", ".join(f'"{f}"' for f in needed_fields)
@@ -535,7 +537,11 @@ def _request_openai_metadata(
                 "schema": {
                     "type": "object",
                     "properties": {
-                        f: ({"type": "array", "items": {"type": "string"}} if f == "tags" else {"type": "string"})
+                        f: (
+                            {"type": "array", "items": {"type": "string"}}
+                            if f == "tags"
+                            else {"type": "string"}
+                        )
                         for f in needed_fields
                     },
                     "required": sorted(needed_fields),

--- a/main.py
+++ b/main.py
@@ -681,7 +681,16 @@ def _populate_missing_metadata(
     ai_eligible = ["title", "description", "caption", "tags"]
 
     if only_fields is not None:
-        needed_fields = [f for f in only_fields if f in ai_eligible]
+        needed_fields = []
+        for f in only_fields:
+            if f not in ai_eligible:
+                continue
+            val = metadata.get(f)
+            if f == "tags":
+                if not val:
+                    needed_fields.append(f)
+            elif not (val or "").strip():
+                needed_fields.append(f)
     else:
         needed_fields = []
         for field in ai_eligible:
@@ -1453,11 +1462,15 @@ async def update_image_metadata(
     }
     existing = _load_metadata(image_path)
     prior_ai = set(existing.get("ai_fields", []))
+    if prior_ai:
+        changed = {
+            f
+            for f in ("title", "description", "caption", "tags")
+            if f in clean_metadata and clean_metadata[f] != existing.get(f)
+        }
+        existing["ai_fields"] = sorted(prior_ai - changed)
     existing.update(clean_metadata)
     existing["status"] = "approved"
-    if prior_ai:
-        edited = {f for f in ("title", "description", "caption", "tags") if f in clean_metadata}
-        existing["ai_fields"] = sorted(prior_ai - edited)
     _write_sidecar(image_path, existing)
 
     return RedirectResponse(

--- a/main.py
+++ b/main.py
@@ -1237,11 +1237,20 @@ async def regenerate_ai_metadata(
         body = {}
     images = body.get("images") or []
     force = bool(body.get("force", False))
-    fields: list[str] | None = body.get("fields")
-    if isinstance(fields, list):
+    fields: list[str] | None
+    if "fields" not in body or body.get("fields") is None:
+        fields = None
+    elif not isinstance(body.get("fields"), list):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="fields must be a JSON array. Supported values: title, description, caption, tags",
+        )
+    else:
         fields = list(
             dict.fromkeys(
-                f for f in fields if f in ("title", "description", "caption", "tags")
+                f
+                for f in body["fields"]
+                if f in ("title", "description", "caption", "tags")
             )
         )
         if not fields:
@@ -1249,8 +1258,6 @@ async def regenerate_ai_metadata(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="No supported fields provided. Use: title, description, caption, tags",
             )
-    else:
-        fields = None
 
     if not isinstance(images, list) or not images:
         raise HTTPException(

--- a/scripts/migrate_v2.py
+++ b/scripts/migrate_v2.py
@@ -96,6 +96,11 @@ def main() -> None:
             errors += 1
             continue
 
+        if not isinstance(data, dict):
+            print(f"[error] {name}: expected JSON object, got {type(data).__name__}")
+            errors += 1
+            continue
+
         data, changed = migrate_sidecar(data)
 
         try:

--- a/scripts/migrate_v2.py
+++ b/scripts/migrate_v2.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Migrate image sidecars to v2 schema.
+
+Adds missing v2 fields (caption, tags, artist, copyright, collection, ai_fields),
+copies author→artist, and infers ai_fields from ai_generated flag.
+
+Idempotent — safe to re-run. Validates against the updated schema after migration.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from jsonschema import validate as js_validate, ValidationError
+except ImportError:
+    print("jsonschema not installed. Run: pip install jsonschema", file=sys.stderr)
+    sys.exit(1)
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = ROOT / "ImageSidecar.schema.json"
+DEFAULT_IMAGES_DIR = ROOT / "Static" / "images"
+
+V2_DEFAULTS: dict[str, object] = {
+    "caption": "",
+    "tags": [],
+    "artist": "",
+    "copyright": "",
+    "collection": "",
+    "ai_fields": [],
+}
+
+
+def load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def migrate_sidecar(data: dict) -> tuple[dict, bool]:
+    """Apply v2 migration to a sidecar dict. Returns (data, changed)."""
+    changed = False
+
+    for key, default in V2_DEFAULTS.items():
+        if key not in data:
+            data[key] = default if not isinstance(default, list) else list(default)
+            changed = True
+
+    if data.get("author") and not data.get("artist"):
+        data["artist"] = data["author"]
+        changed = True
+
+    if "ai_fields" in data and not data["ai_fields"]:
+        if data.get("ai_generated"):
+            data["ai_fields"] = ["title", "description"]
+            changed = True
+
+    return data, changed
+
+
+def atomic_write(path: Path, data: dict) -> None:
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def main() -> None:
+    images_dir = Path(os.environ.get("IMAGES_DIR", str(DEFAULT_IMAGES_DIR)))
+    if not images_dir.is_dir():
+        print(f"Images directory not found: {images_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    schema = load_schema()
+    migrated = 0
+    errors = 0
+    current = 0
+
+    for name in sorted(os.listdir(images_dir)):
+        if not name.lower().endswith(".json"):
+            continue
+        json_path = images_dir / name
+
+        try:
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"[error] {name}: {exc}")
+            errors += 1
+            continue
+
+        data, changed = migrate_sidecar(data)
+
+        try:
+            js_validate(instance=data, schema=schema)
+        except ValidationError as exc:
+            print(f"[warn] {name} failed validation after migration: {exc.message}")
+            errors += 1
+            continue
+
+        if changed:
+            atomic_write(json_path, data)
+            migrated += 1
+        else:
+            current += 1
+
+    total = migrated + current + errors
+    print(f"\nMigration complete: {total} sidecars processed")
+    print(f"  Migrated: {migrated}")
+    print(f"  Already current: {current}")
+    print(f"  Errors: {errors}")
+
+    if errors:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_v2.py
+++ b/scripts/migrate_v2.py
@@ -51,10 +51,9 @@ def migrate_sidecar(data: dict) -> tuple[dict, bool]:
         data["artist"] = data["author"]
         changed = True
 
-    if "ai_fields" in data and not data["ai_fields"]:
-        if data.get("ai_generated"):
-            data["ai_fields"] = ["title", "description"]
-            changed = True
+    if "ai_fields" in data and not data["ai_fields"] and data.get("ai_generated"):
+        data["ai_fields"] = ["title", "description"]
+        changed = True
 
     return data, changed
 

--- a/scripts/migrate_v2.py
+++ b/scripts/migrate_v2.py
@@ -14,7 +14,8 @@ import tempfile
 from pathlib import Path
 
 try:
-    from jsonschema import validate as js_validate, ValidationError
+    from jsonschema import ValidationError
+    from jsonschema import validate as js_validate
 except ImportError:
     print("jsonschema not installed. Run: pip install jsonschema", file=sys.stderr)
     sys.exit(1)

--- a/templates/artwork_detail.html
+++ b/templates/artwork_detail.html
@@ -8,7 +8,7 @@
     <link href="https://api.fontshare.com/v2/css?f[]=clash-grotesk@200,300,400,500,600,700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
-    <script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
+    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
 </head>
 <body>
 

--- a/templates/artwork_detail.html
+++ b/templates/artwork_detail.html
@@ -13,7 +13,7 @@
 <body>
 
     <header>
-        <a href="/" class="artwork-meta-label" style="text-decoration: none; color: inherit; margin-bottom: 2rem; display: inline-block;">&larr; Back to Gallery</a>
+        <a href="{{ url_for('read_root') }}" class="artwork-meta-label" style="text-decoration: none; color: inherit; margin-bottom: 2rem; display: inline-block;">&larr; Back to Gallery</a>
         <h1>{{ artwork.title }}</h1>
     </header>
 
@@ -68,12 +68,12 @@
         {% if prev_artwork or next_artwork %}
         <nav style="display: flex; justify-content: space-between; margin-top: 4rem; padding-top: 2rem; border-top: 1px solid var(--border-color);">
             {% if prev_artwork %}
-            <a href="/artwork/{{ prev_artwork }}" class="button secondary">&larr; Previous</a>
+            <a href="{{ url_for('artwork_detail', image_filename=prev_artwork) }}" class="button secondary">&larr; Previous</a>
             {% else %}
             <span></span>
             {% endif %}
             {% if next_artwork %}
-            <a href="/artwork/{{ next_artwork }}" class="button secondary">Next &rarr;</a>
+            <a href="{{ url_for('artwork_detail', image_filename=next_artwork) }}" class="button secondary">Next &rarr;</a>
             {% endif %}
         </nav>
         {% endif %}

--- a/templates/artwork_detail.html
+++ b/templates/artwork_detail.html
@@ -8,31 +8,75 @@
     <link href="https://api.fontshare.com/v2/css?f[]=clash-grotesk@200,300,400,500,600,700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
+    <script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
 </head>
 <body>
 
     <header>
-        <a href="/" style="font-family: var(--font-mono); font-size: 0.75rem; text-decoration: none; color: inherit; opacity: 0.6; text-transform: uppercase; margin-bottom: 2rem; display: inline-block;">← Back to Gallery</a>
+        <a href="/" class="artwork-meta-label" style="text-decoration: none; color: inherit; margin-bottom: 2rem; display: inline-block;">&larr; Back to Gallery</a>
         <h1>{{ artwork.title }}</h1>
     </header>
 
     <div class="shader-bg"></div>
 
     <main>
-        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 4rem; align-items: start;">
+        <div class="artwork-detail-grid">
             <div>
-                <img src="{{ artwork.image_url }}" alt="{{ artwork.title }}" style="width: 100%; height: auto; border-radius: var(--radius-sm); filter: grayscale(10%); transition: filter 0.5s ease;" onmouseover="this.style.filter='grayscale(0%)'" onmouseout="this.style.filter='grayscale(10%)'">
+                <img src="{{ artwork.image_url }}" alt="{{ artwork.title }}">
             </div>
-            <div style="padding-top: 4rem;">
-                <p class="tagline" style="font-family: var(--font-mono); font-size: 0.75rem; text-transform: uppercase; opacity: 0.6; margin-bottom: 1rem;">Artifact Description</p>
-                <div style="font-size: 1.25rem; line-height: 1.6; max-width: 40ch;">
+            <div style="padding-top: 2rem;">
+                {% if artwork.caption %}
+                <p class="artwork-meta-label">Caption</p>
+                <p class="artwork-meta-value">{{ artwork.caption }}</p>
+                {% endif %}
+
+                <p class="artwork-meta-label">Description</p>
+                <div class="artwork-meta-value" style="max-width: 40ch;">
                     {{ artwork.description }}
                 </div>
-                <div style="margin-top: 4rem; font-family: var(--font-mono); font-size: 0.75rem; opacity: 0.4;">
+
+                {% if artwork.artist %}
+                <p class="artwork-meta-label">Artist</p>
+                <p class="artwork-meta-value">{{ artwork.artist }}</p>
+                {% endif %}
+
+                {% if artwork.tags %}
+                <p class="artwork-meta-label">Tags</p>
+                <div class="tag-list" style="margin-bottom: 1.5rem;">
+                    {% for tag in artwork.tags %}
+                    <span class="tag-pill">{{ tag }}</span>
+                    {% endfor %}
+                </div>
+                {% endif %}
+
+                {% if artwork.collection %}
+                <p class="artwork-meta-label">Collection</p>
+                <p class="artwork-meta-value">{{ artwork.collection }}</p>
+                {% endif %}
+
+                {% if artwork.copyright %}
+                <p class="artwork-meta-label">Copyright</p>
+                <p class="artwork-meta-value">{{ artwork.copyright }}</p>
+                {% endif %}
+
+                <div class="artwork-meta-label" style="margin-top: 4rem; opacity: 0.4;">
                     AUTHENTICATED ARTIFACT / ART.AZZEN.COM
                 </div>
             </div>
         </div>
+
+        {% if prev_artwork or next_artwork %}
+        <nav style="display: flex; justify-content: space-between; margin-top: 4rem; padding-top: 2rem; border-top: 1px solid var(--border-color);">
+            {% if prev_artwork %}
+            <a href="/artwork/{{ prev_artwork }}" class="button secondary">&larr; Previous</a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if next_artwork %}
+            <a href="/artwork/{{ next_artwork }}" class="button secondary">Next &rarr;</a>
+            {% endif %}
+        </nav>
+        {% endif %}
     </main>
 
     <footer>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
     <meta charset="UTF-8">
+    <script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ gallery_title }}</title>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
+    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ gallery_title }}</title>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ gallery_title }}</title>

--- a/templates/previewImageText.html
+++ b/templates/previewImageText.html
@@ -118,7 +118,7 @@
         document.querySelectorAll('.field-regen-btn').forEach(function(btn) {
             btn.addEventListener('click', async function() {
                 var field = btn.dataset.field;
-                var imageName = '{{ image_name | e }}';
+                var imageName = {{ image_name | tojson }};
                 btn.disabled = true;
                 btn.textContent = '…';
                 try {

--- a/templates/previewImageText.html
+++ b/templates/previewImageText.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
+    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Review {{ metadata.title }} &mdash; Artwork Admin</title>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
@@ -16,7 +16,7 @@
         <p class="admin-subheading">Curating metadata for artifact</p>
         <nav class="admin-nav">
             <a href="{{ review_url }}" class="button secondary">Back to pending list</a>
-            <a href="/" class="button secondary">View Public Gallery</a>
+            <a href="{{ url_for('read_root') }}" class="button secondary">View Public Gallery</a>
         </nav>
     </header>
 

--- a/templates/previewImageText.html
+++ b/templates/previewImageText.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
 </head>
-<body class="admin-page">
+<body class="admin-page" data-root-path="{{ request.scope.get('root_path', '') }}">
     <header>
         <h1>Review</h1>
         <p class="admin-subheading">Curating metadata for artifact</p>
@@ -55,19 +55,44 @@
         </section>
 
         <section class="admin-panel">
-            <h2>Edit text for this image</h2>
-            <p class="panel-description">Update the fields below to control the title and description that accompany the artwork in the public gallery. Saving will also update or create the JSON sidecar file.</p>
+            <h2>Edit metadata</h2>
+            <p class="panel-description">Update the fields below. Saving approves the artwork and updates its JSON sidecar.</p>
             <form class="metadata-form" method="post" action="{{ url_for('update_image_metadata', image_name=image_name) }}">
                 <div class="form-field">
-                    <label for="title">Title</label>
+                    <label for="title">Title <button type="button" class="field-regen-btn" data-field="title">AI</button></label>
                     <input type="text" id="title" name="title" value="{{ metadata.title | e }}" required>
                 </div>
                 <div class="form-field">
-                    <label for="description">Description</label>
-                    <textarea id="description" name="description" rows="6" placeholder="Describe the story, medium, or inspiration for this piece.">{{ metadata.description | e }}</textarea>
+                    <label for="description">Description <button type="button" class="field-regen-btn" data-field="description">AI</button></label>
+                    <textarea id="description" name="description" rows="4" placeholder="Describe the story, medium, or inspiration.">{{ metadata.description | e }}</textarea>
                 </div>
+                <div class="form-field">
+                    <label for="caption">Caption <button type="button" class="field-regen-btn" data-field="caption">AI</button></label>
+                    <input type="text" id="caption" name="caption" value="{{ metadata.get('caption', '') | e }}" placeholder="Short gallery caption">
+                </div>
+                <div class="form-field">
+                    <label for="tags">Tags <button type="button" class="field-regen-btn" data-field="tags">AI</button></label>
+                    <input type="text" id="tags" name="tags" value="{{ metadata.get('tags', []) | join(', ') }}" placeholder="Comma-separated tags">
+                </div>
+                <div class="form-field">
+                    <label for="artist">Artist</label>
+                    <input type="text" id="artist" name="artist" value="{{ metadata.get('artist', '') | e }}">
+                </div>
+                <div class="form-field">
+                    <label for="copyright">Copyright</label>
+                    <input type="text" id="copyright" name="copyright" value="{{ metadata.get('copyright', '') | e }}">
+                </div>
+                <div class="form-field">
+                    <label for="collection">Collection</label>
+                    <input type="text" id="collection" name="collection" value="{{ metadata.get('collection', '') | e }}">
+                </div>
+                {% if metadata.get('ai_fields') %}
+                <p class="ai-status">
+                    <span class="badge">AI fields: {{ metadata.ai_fields | join(', ') }}</span>
+                </p>
+                {% endif %}
                 <div class="form-actions">
-                    <button type="submit" name="action" value="save" class="button">OK</button>
+                    <button type="submit" name="action" value="save" class="button">Approve &amp; Save</button>
                     <button type="submit" name="action" value="cancel" class="button secondary">Cancel</button>
                 </div>
             </form>
@@ -79,15 +104,47 @@
     </footer>
 
     <script>
-    // Format any server-rendered timestamps on this page
     (function () {
+        var ROOT = document.body.dataset.rootPath || '';
+
         document.querySelectorAll('.ai-status .timestamp[data-ts]')
-            .forEach((el) => {
-                const ts = parseFloat(el.getAttribute('data-ts'));
+            .forEach(function(el) {
+                var ts = parseFloat(el.getAttribute('data-ts'));
                 if (!isNaN(ts)) {
                     el.textContent = ' · ' + new Date(ts * 1000).toLocaleString();
                 }
             });
+
+        document.querySelectorAll('.field-regen-btn').forEach(function(btn) {
+            btn.addEventListener('click', async function() {
+                var field = btn.dataset.field;
+                var imageName = '{{ image_name | e }}';
+                btn.disabled = true;
+                btn.textContent = '…';
+                try {
+                    var res = await fetch(ROOT + '/admin/ai/regenerate', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({images: [imageName], fields: [field], force: true})
+                    });
+                    var data = await res.json();
+                    if (!res.ok) throw new Error(data.detail || 'Failed');
+                    var updated = (data.updated || [])[0];
+                    if (updated && updated.metadata) {
+                        var val = updated.metadata[field];
+                        var input = document.getElementById(field);
+                        if (input) {
+                            input.value = Array.isArray(val) ? val.join(', ') : (val || '');
+                        }
+                    }
+                    btn.textContent = '✓';
+                    setTimeout(function() { btn.textContent = 'AI'; btn.disabled = false; }, 2000);
+                } catch (e) {
+                    btn.textContent = '✗';
+                    setTimeout(function() { btn.textContent = 'AI'; btn.disabled = false; }, 2000);
+                }
+            });
+        });
     })();
     </script>
 </body>

--- a/templates/previewImageText.html
+++ b/templates/previewImageText.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Review {{ metadata.title }} &mdash; Artwork Admin</title>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
@@ -59,20 +60,20 @@
             <p class="panel-description">Update the fields below. Saving approves the artwork and updates its JSON sidecar.</p>
             <form class="metadata-form" method="post" action="{{ url_for('update_image_metadata', image_name=image_name) }}">
                 <div class="form-field">
-                    <label for="title">Title <button type="button" class="field-regen-btn" data-field="title">AI</button></label>
-                    <input type="text" id="title" name="title" value="{{ metadata.title | e }}" required>
+                    <label for="title">Title</label>
+                    <div class="field-with-regen"><input type="text" id="title" name="title" value="{{ metadata.title | e }}" required><button type="button" class="field-regen-btn" data-field="title" aria-label="Regenerate title with AI">AI</button></div>
                 </div>
                 <div class="form-field">
-                    <label for="description">Description <button type="button" class="field-regen-btn" data-field="description">AI</button></label>
-                    <textarea id="description" name="description" rows="4" placeholder="Describe the story, medium, or inspiration.">{{ metadata.description | e }}</textarea>
+                    <label for="description">Description</label>
+                    <div class="field-with-regen"><textarea id="description" name="description" rows="4" placeholder="Describe the story, medium, or inspiration.">{{ metadata.description | e }}</textarea><button type="button" class="field-regen-btn" data-field="description" aria-label="Regenerate description with AI">AI</button></div>
                 </div>
                 <div class="form-field">
-                    <label for="caption">Caption <button type="button" class="field-regen-btn" data-field="caption">AI</button></label>
-                    <input type="text" id="caption" name="caption" value="{{ metadata.get('caption', '') | e }}" placeholder="Short gallery caption">
+                    <label for="caption">Caption</label>
+                    <div class="field-with-regen"><input type="text" id="caption" name="caption" value="{{ metadata.get('caption', '') | e }}" placeholder="Short gallery caption"><button type="button" class="field-regen-btn" data-field="caption" aria-label="Regenerate caption with AI">AI</button></div>
                 </div>
                 <div class="form-field">
-                    <label for="tags">Tags <button type="button" class="field-regen-btn" data-field="tags">AI</button></label>
-                    <input type="text" id="tags" name="tags" value="{{ metadata.get('tags', []) | join(', ') }}" placeholder="Comma-separated tags">
+                    <label for="tags">Tags</label>
+                    <div class="field-with-regen"><input type="text" id="tags" name="tags" value="{{ metadata.get('tags', []) | join(', ') }}" placeholder="Comma-separated tags"><button type="button" class="field-regen-btn" data-field="tags" aria-label="Regenerate tags with AI">AI</button></div>
                 </div>
                 <div class="form-field">
                     <label for="artist">Artist</label>

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
     <meta charset="UTF-8">
+    <script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Artwork Admin</title>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Artwork Admin</title>
@@ -172,10 +173,39 @@
                     </div>
                 </form>
             </section>
+            <section class="admin-panel">
+                <h2>Appearance</h2>
+                <div class="form-row">
+                    <button type="button" id="dark-mode-toggle" class="dark-mode-toggle">Toggle dark mode</button>
+                </div>
+            </section>
         </main>
     </div>
 
     <section id="feedback" class="feedback" role="status" aria-live="polite" hidden></section>
+
+    <nav class="admin-bottom-tabs" aria-label="Admin navigation">
+        <button class="admin-bottom-tab active" data-tab="dashboard" aria-label="Dashboard">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+            Queue
+        </button>
+        <a class="admin-bottom-tab" href="#" aria-label="Review">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M12 8v4m0 0v4m0-4h4m-4 0H8"/></svg>
+            Review
+        </a>
+        <button class="admin-bottom-tab" id="capture-tab" aria-label="Capture">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="13" r="3"/><path d="M5 7h2l2-3h6l2 3h2a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9a2 2 0 012-2z"/></svg>
+            Capture
+        </button>
+        <a class="admin-bottom-tab" href="{{ url_for('read_root') }}" aria-label="Gallery">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+            Gallery
+        </a>
+        <button class="admin-bottom-tab" data-tab="settings" aria-label="Settings">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+            Settings
+        </button>
+    </nav>
 
     <footer>
         <p>Artwork Gallery Administration</p>
@@ -545,6 +575,38 @@
     }, 15000);
 
     loadConfig();
+
+    // Dark mode toggle
+    const darkToggle = document.getElementById('dark-mode-toggle');
+    darkToggle?.addEventListener('click', () => {
+        const root = document.documentElement;
+        if (root.classList.contains('az-dark')) {
+            root.classList.remove('az-dark');
+            root.classList.add('az-light');
+            localStorage.setItem('az-theme', 'az-light');
+        } else {
+            root.classList.remove('az-light');
+            root.classList.add('az-dark');
+            localStorage.setItem('az-theme', 'az-dark');
+        }
+    });
+
+    // Bottom tab bar — sync with top tabs
+    document.querySelectorAll('.admin-bottom-tab[data-tab]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const tabId = btn.dataset.tab;
+            const topTab = document.getElementById('btn-' + tabId);
+            if (topTab) topTab.click();
+            document.querySelectorAll('.admin-bottom-tab').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            window.scrollTo({top: 0, behavior: 'smooth'});
+        });
+    });
+
+    // Capture tab — trigger file input
+    document.getElementById('capture-tab')?.addEventListener('click', () => {
+        fileInput?.click();
+    });
     </script>
 </body>
 </html>

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <script>(function(){var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)})()</script>
+    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Artwork Admin</title>
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
@@ -185,7 +185,7 @@
     <section id="feedback" class="feedback" role="status" aria-live="polite" hidden></section>
 
     <nav class="admin-bottom-tabs" aria-label="Admin navigation">
-        <button class="admin-bottom-tab active" data-tab="dashboard" aria-label="Dashboard">
+        <button class="admin-bottom-tab active" data-tab="dashboard" aria-label="Queue">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             Queue
         </button>

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -189,10 +189,10 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             Queue
         </button>
-        <a class="admin-bottom-tab" href="#" aria-label="Review">
+        <button class="admin-bottom-tab" data-tab="review" aria-label="Review">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M12 8v4m0 0v4m0-4h4m-4 0H8"/></svg>
             Review
-        </a>
+        </button>
         <button class="admin-bottom-tab" id="capture-tab" aria-label="Capture">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="13" r="3"/><path d="M5 7h2l2-3h6l2 3h2a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9a2 2 0 012-2z"/></svg>
             Capture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -367,7 +367,7 @@ def test_openai_http_error_details_are_not_exposed(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(gallery_app.httpx, "Client", FailingClient)
 
-    result = gallery_app._request_openai_metadata(image_path, {}, True, True)
+    result = gallery_app._request_openai_metadata(image_path, {}, ["title", "description"])
     details = result["details"]
 
     assert details["error"] == "OpenAI metadata request failed."
@@ -418,7 +418,122 @@ def test_openai_parse_error_details_are_not_exposed(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(gallery_app.httpx, "Client", InvalidJsonClient)
 
-    result = gallery_app._request_openai_metadata(image_path, {}, True, True)
+    result = gallery_app._request_openai_metadata(image_path, {}, ["title", "description"])
 
     assert result["details"]["error"] == "OpenAI metadata response could not be parsed."
     assert secret_detail not in result["details"]["error"]
+
+
+# ---------------------------------------------------------------------------
+# Collections API
+# ---------------------------------------------------------------------------
+
+
+def test_collections_requires_auth(client: TestClient):
+    response = client.get("/admin/api/collections")
+    assert response.status_code in (401, 503)
+
+
+def test_collections_returns_distinct_values(authed_client, tmp_path, monkeypatch):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+    (image_root / "a.json").write_text(json.dumps({"collection": "Flora"}))
+    (image_root / "b.json").write_text(json.dumps({"collection": "Flora"}))
+    (image_root / "c.json").write_text(json.dumps({"collection": "Fauna"}))
+    (image_root / "d.json").write_text(json.dumps({"collection": ""}))
+
+    response = authed_client.get("/admin/api/collections")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["collections"] == ["Fauna", "Flora"]
+
+
+# ---------------------------------------------------------------------------
+# Per-field regeneration
+# ---------------------------------------------------------------------------
+
+
+def test_regenerate_with_fields_blanks_only_targeted(monkeypatch, tmp_path):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    img = image_root / "field_test.jpg"
+    img.touch()
+    sidecar = image_root / "field_test.json"
+    sidecar.write_text(json.dumps({
+        "title": "Keep", "description": "Keep", "caption": "Keep",
+        "tags": ["keep"], "ai_generated": False, "ai_fields": [],
+        "status": "pending", "detected_at": 0, "ai_details": {},
+    }))
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+    monkeypatch.setattr(
+        gallery_app, "_populate_missing_metadata",
+        lambda path, meta, only_fields=None: meta,
+    )
+    monkeypatch.setattr(
+        gallery_app, "_refresh_pending_files", lambda _req: [],
+    )
+
+    body = json.dumps({"images": ["field_test.jpg"], "fields": ["caption"], "force": True}).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/admin/ai/regenerate",
+         "headers": [(b"content-type", b"application/json")], "app": app},
+        receive,
+    )
+    response = asyncio.run(gallery_app.regenerate_ai_metadata(request, _=None))
+    payload = json.loads(response.body)
+
+    assert len(payload["updated"]) == 1
+    meta = payload["updated"][0]["metadata"]
+    assert meta["title"] == "Keep"
+    assert meta["description"] == "Keep"
+    assert meta["caption"] == ""
+    assert meta["tags"] == ["keep"]
+
+
+# ---------------------------------------------------------------------------
+# Metadata POST persists v2 fields
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_post_persists_v2_fields(authed_client, tmp_path, monkeypatch):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    img = image_root / "v2test.jpg"
+    img.touch()
+    sidecar = image_root / "v2test.json"
+    sidecar.write_text(json.dumps({
+        "title": "", "description": "", "caption": "", "tags": [],
+        "artist": "", "copyright": "", "collection": "",
+        "ai_generated": False, "ai_fields": [], "ai_details": {},
+        "status": "pending", "detected_at": 0,
+    }))
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+
+    response = authed_client.post(
+        "/admin/metadata/v2test.jpg",
+        data={
+            "title": "Bloom",
+            "description": "A flower",
+            "caption": "Delicate petals",
+            "tags": "botanical, flora",
+            "artist": "Ada",
+            "copyright": "2026",
+            "collection": "Garden",
+            "action": "save",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+
+    saved = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert saved["caption"] == "Delicate petals"
+    assert saved["tags"] == ["botanical", "flora"]
+    assert saved["artist"] == "Ada"
+    assert saved["copyright"] == "2026"
+    assert saved["collection"] == "Garden"
+    assert saved["status"] == "approved"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -573,3 +573,30 @@ def test_metadata_post_persists_v2_fields(authed_client, tmp_path, monkeypatch):
     assert saved["copyright"] == "2026"
     assert saved["collection"] == "Garden"
     assert saved["status"] == "approved"
+
+
+def test_regenerate_rejects_unsupported_fields(monkeypatch, tmp_path):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    (image_root / "x.jpg").touch()
+    monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
+
+    body = json.dumps({"images": ["x.jpg"], "fields": ["artist"]}).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/admin/ai/regenerate",
+            "headers": [(b"content-type", b"application/json")],
+            "app": app,
+        },
+        receive,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(gallery_app.regenerate_ai_metadata(request, _=None))
+    assert exc_info.value.status_code == 400
+    assert "No supported fields" in exc_info.value.detail

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -367,7 +367,9 @@ def test_openai_http_error_details_are_not_exposed(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(gallery_app.httpx, "Client", FailingClient)
 
-    result = gallery_app._request_openai_metadata(image_path, {}, ["title", "description"])
+    result = gallery_app._request_openai_metadata(
+        image_path, {}, ["title", "description"]
+    )
     details = result["details"]
 
     assert details["error"] == "OpenAI metadata request failed."
@@ -418,7 +420,9 @@ def test_openai_parse_error_details_are_not_exposed(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(gallery_app.httpx, "Client", InvalidJsonClient)
 
-    result = gallery_app._request_openai_metadata(image_path, {}, ["title", "description"])
+    result = gallery_app._request_openai_metadata(
+        image_path, {}, ["title", "description"]
+    )
 
     assert result["details"]["error"] == "OpenAI metadata response could not be parsed."
     assert secret_detail not in result["details"]["error"]
@@ -460,28 +464,48 @@ def test_regenerate_with_fields_blanks_only_targeted(monkeypatch, tmp_path):
     img = image_root / "field_test.jpg"
     img.touch()
     sidecar = image_root / "field_test.json"
-    sidecar.write_text(json.dumps({
-        "title": "Keep", "description": "Keep", "caption": "Keep",
-        "tags": ["keep"], "ai_generated": False, "ai_fields": [],
-        "status": "pending", "detected_at": 0, "ai_details": {},
-    }))
+    sidecar.write_text(
+        json.dumps(
+            {
+                "title": "Keep",
+                "description": "Keep",
+                "caption": "Keep",
+                "tags": ["keep"],
+                "ai_generated": False,
+                "ai_fields": [],
+                "status": "pending",
+                "detected_at": 0,
+                "ai_details": {},
+            }
+        )
+    )
     monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
     monkeypatch.setattr(
-        gallery_app, "_populate_missing_metadata",
+        gallery_app,
+        "_populate_missing_metadata",
         lambda path, meta, only_fields=None: meta,
     )
     monkeypatch.setattr(
-        gallery_app, "_refresh_pending_files", lambda _req: [],
+        gallery_app,
+        "_refresh_pending_files",
+        lambda _req: [],
     )
 
-    body = json.dumps({"images": ["field_test.jpg"], "fields": ["caption"], "force": True}).encode()
+    body = json.dumps(
+        {"images": ["field_test.jpg"], "fields": ["caption"], "force": True}
+    ).encode()
 
     async def receive():
         return {"type": "http.request", "body": body, "more_body": False}
 
     request = Request(
-        {"type": "http", "method": "POST", "path": "/admin/ai/regenerate",
-         "headers": [(b"content-type", b"application/json")], "app": app},
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/admin/ai/regenerate",
+            "headers": [(b"content-type", b"application/json")],
+            "app": app,
+        },
         receive,
     )
     response = asyncio.run(gallery_app.regenerate_ai_metadata(request, _=None))
@@ -506,12 +530,24 @@ def test_metadata_post_persists_v2_fields(authed_client, tmp_path, monkeypatch):
     img = image_root / "v2test.jpg"
     img.touch()
     sidecar = image_root / "v2test.json"
-    sidecar.write_text(json.dumps({
-        "title": "", "description": "", "caption": "", "tags": [],
-        "artist": "", "copyright": "", "collection": "",
-        "ai_generated": False, "ai_fields": [], "ai_details": {},
-        "status": "pending", "detected_at": 0,
-    }))
+    sidecar.write_text(
+        json.dumps(
+            {
+                "title": "",
+                "description": "",
+                "caption": "",
+                "tags": [],
+                "artist": "",
+                "copyright": "",
+                "collection": "",
+                "ai_generated": False,
+                "ai_fields": [],
+                "ai_details": {},
+                "status": "pending",
+                "detected_at": 0,
+            }
+        )
+    )
     monkeypatch.setattr(gallery_app, "IMAGES_DIR", image_root)
 
     response = authed_client.post(


### PR DESCRIPTION
## Summary

- **Schema v2**: Extends `ImageSidecar.schema.json` with `caption`, `tags[]`, `artist`, `copyright`, `collection`, and `ai_fields[]` tracking. Keeps `author` and `reviewed` as deprecated.
- **Per-field AI regeneration**: `POST /admin/ai/regenerate` now accepts a `fields` parameter for selective regeneration of individual metadata fields (title, caption, description, tags), preserving human-edited values. Tracked via `ai_fields` array.
- **Collections API**: New `GET /admin/api/collections` endpoint returns distinct collection values across all sidecars.
- **Mobile responsive CSS**: Admin layout adapts to mobile (≤600px) with single-column grids, 44px touch targets, and bottom tab bar navigation.
- **Dark mode**: `.az-light`/`.az-dark` class-based toggle persisted to localStorage, with `prefers-color-scheme` as default.
- **Template v2 fields**: `artwork_detail.html` and `previewImageText.html` display and edit all v2 fields. Per-field AI regen buttons in review form.
- **Sidecar migration script**: `scripts/migrate_v2.py` — idempotent, adds v2 defaults, copies `author→artist`, infers `ai_fields`. Atomic writes.
- **SwiftUI spec package**: 22 Swift files in `ArtazzenMobile/` — iOS 17+ spec with 5-tab TabView, swipe deck review, PhotosPicker capture, per-field AI regeneration, Techno-Botanical design tokens. Spec-only (cannot compile on Linux).

## Post-deploy step

After merging to `main` and deploying, run the migration on the Railway volume:

```bash
IMAGES_DIR=/data/images python scripts/migrate_v2.py
```

## Behavior change note

Images with empty `caption` or `tags` will now trigger AI calls on review page load when AI is enabled. This is intentional to populate v2 fields but represents a cost increase over the previous behavior (which only checked `title` and `description`).

## Test plan

- [x] `pytest tests/ -x -q` — 25 passed (4 new tests for collections API, per-field regen, v2 metadata persistence)
- [x] `python manage_sidecars.py validate` — 184 validated, 0 errors
- [x] `python -c "import main"` — clean import
- [ ] Manual: verify mobile layout at ≤600px viewport
- [ ] Manual: verify dark mode toggle in admin settings tab
- [ ] Manual: verify per-field AI regen buttons on review page
- [ ] Manual: verify artwork detail page shows v2 fields (caption, tags, artist, collection, copyright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7K87xzbXSDjstYXYnpm5j
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

