### PR TITLE
chore(deps): consolidate 8 Dependabot PRs into one

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Lint & format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -29,9 +29,9 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -46,9 +46,9 @@ jobs:
     name: Tests & coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-xml
           path: coverage.xml
@@ -71,16 +71,16 @@ jobs:
     name: Prettier (docs & config)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: npx --yes prettier --check "**/*.{md,yml,yaml,json}" --ignore-path .gitignore
 
   security:
     name: Security scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ h11==0.16.0
 httpcore==1.0.9
 httptools==0.6.4
 httpx==0.28.1
-idna==3.10
+idna==3.15
 iniconfig==2.3.0
 itsdangerous==2.2.0
 jinja2==3.1.6
@@ -29,10 +29,10 @@ markupsafe==3.0.2
 mdurl==0.1.2
 mypy==2.3.1
 mypy-extensions==1.1.0
-orjson==3.11.6
+orjson==3.11.9
 packaging==26.3
 pathspec==1.1.1
-pillow==12.2.0
+pillow==12.3.0
 platformdirs==4.11.3
 playwright==1.62.0
 pluggy==1.6.0
@@ -46,7 +46,7 @@ pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 python-dotenv==1.2.2
-python-multipart==0.0.27
+python-multipart==0.0.31
 pytokens==0.4.1
 pyyaml==6.0.2
 referencing==0.36.2
@@ -64,9 +64,9 @@ typer==0.16.0
 types-pillow==10.2.0.20240822
 typing-extensions==4.14.1
 typing-inspection==0.4.1
-ujson==5.12.0
-urllib3==2.6.3
+ujson==5.13.0
+urllib3==2.7.0
 uvicorn==0.35.0
 uvloop==0.21.0
 watchfiles==1.1.0
-websockets==15.0.1
+websockets==17.0.1


### PR DESCRIPTION
## Summary

- Consolidates all non-conflicting Dependabot updates into a single PR to avoid serial merge conflicts
- Bumps 4 GitHub Actions (checkout, setup-python, upload-artifact, fetch-metadata) and 7 Python packages (orjson, pillow, idna, python-multipart, ujson, urllib3, websockets)
- Excludes 2 updates that fail CI due to dependency conflicts: starlette 1.3.1 (blocked by fastapi 0.116.1's `<0.48.0` cap) and fastapi-cloud-cli 0.23.0 (requires `rich-toolkit>=0.20.3`)

**Supersedes:** #48, #49, #50, #51, #53, #54, #55, #58

## Test plan

- [ ] CI passes (lint, typecheck, tests, prettier, security)
- [ ] `pip install -r requirements.txt` resolves cleanly (verified locally via dry-run)
- [ ] Close superseded PRs after merge (most should auto-close when Dependabot detects the versions on dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7K87xzbXSDjstYXYnpm5j
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

