### PR TITLE
feat: base templates + site navigation

### DIFF
--- a/Static/css/styles.css
+++ b/Static/css/styles.css
@@ -841,3 +841,31 @@ footer {
     white-space: nowrap;
     border-width: 0;
 }
+
+/* --- Site navigation (base template) --- */
+.site-nav {
+    display: flex;
+    gap: 1.5rem;
+    margin-top: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.site-nav a {
+    color: inherit;
+    text-decoration: none;
+    opacity: 0.7;
+    border-bottom: 1px solid transparent;
+    padding-bottom: 2px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+    opacity: 1;
+    border-bottom-color: currentColor;
+}

--- a/templates/artwork_detail.html
+++ b/templates/artwork_detail.html
@@ -1,24 +1,13 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ artwork.title }} &mdash; Artazzen</title>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
-    <link href="https://api.fontshare.com/v2/css?f[]=clash-grotesk@200,300,400,500,600,700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
-    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
-</head>
-<body>
+{% extends "base.html" %}
 
-    <header>
-        <a href="{{ url_for('read_root') }}" class="artwork-meta-label" style="text-decoration: none; color: inherit; margin-bottom: 2rem; display: inline-block;">&larr; Back to Gallery</a>
-        <h1>{{ artwork.title }}</h1>
-    </header>
+{% block title %}{{ artwork.title }} &mdash; Artazzen{% endblock %}
+{% block page_heading %}{{ artwork.title }}{% endblock %}
 
-    <div class="shader-bg"></div>
+{% block header_pre %}
+<a href="{{ url_for('read_root') }}" class="artwork-meta-label" style="text-decoration: none; color: inherit; margin-bottom: 2rem; display: inline-block;">&larr; Back to Gallery</a>
+{% endblock %}
 
+{% block content %}
     <main>
         <div class="artwork-detail-grid">
             <div>
@@ -78,10 +67,6 @@
         </nav>
         {% endif %}
     </main>
+{% endblock %}
 
-    <footer>
-        <p>Artazzen / {{ artwork.title }}</p>
-    </footer>
-
-</body>
-</html>
+{% block footer %}<p>Artazzen / {{ artwork.title }}</p>{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ gallery_title | default('Artazzen Gallery') }}{% endblock %}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
+    <link href="https://api.fontshare.com/v2/css?f[]=clash-grotesk@200,300,400,500,600,700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎨</text></svg>">
+    {% block head_extra %}{% endblock %}
+</head>
+<body class="{% block body_class %}{% endblock %}"{% block body_attrs %}{% endblock %}>
+
+    <header>
+        {% block header %}
+        {% block header_pre %}{% endblock %}
+        <h1>{% block page_heading %}{{ gallery_title | default('Artazzen Gallery') }}{% endblock %}</h1>
+        {% block header_extra %}{% endblock %}
+        <nav class="site-nav">{% block site_nav %}<a href="{{ url_for('read_root') }}">Gallery</a>{% endblock %}</nav>
+        {% endblock %}
+    </header>
+
+    <div class="shader-bg"></div>
+
+    {% block content %}{% endblock %}
+
+    <footer>
+        {% block footer %}<p>Artazzen</p>{% endblock %}
+    </footer>
+
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/base_admin.html
+++ b/templates/base_admin.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block body_class %}admin-page{% endblock %}
+{% block body_attrs %} data-root-path="{{ request.scope.get('root_path', '') }}"{% endblock %}
+
+{% block header %}
+<h1>{% block admin_heading %}Administration{% endblock %}</h1>
+<p class="admin-subheading">{% block admin_subheading %}Gallery curation and artwork management{% endblock %}</p>
+<nav class="admin-nav">
+    {% block admin_nav %}
+    <a href="{{ url_for('read_root') }}" class="button secondary">View Public Gallery</a>
+    {% endblock %}
+</nav>
+{% endblock %}
+
+{% block footer %}<p>Artwork Gallery Administration</p>{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,25 +1,13 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ gallery_title }}</title>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
-    <link href="https://api.fontshare.com/v2/css?f[]=clash-grotesk@200,300,400,500,600,700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎨</text></svg>">
-</head>
-<body>
+{% extends "base.html" %}
 
-    <header>
-        <h1>{{ gallery_title }}</h1>
-        <p class="tagline" style="font-family: var(--font-mono); font-size: 0.75rem; text-transform: uppercase; opacity: 0.6; margin-top: 1rem;">Curated Art & Data</p>
-    </header>
+{% block title %}{{ gallery_title }}{% endblock %}
+{% block page_heading %}{{ gallery_title }}{% endblock %}
 
-    <div class="shader-bg"></div>
+{% block header_extra %}
+<p class="tagline" style="font-family: var(--font-mono); font-size: 0.75rem; text-transform: uppercase; opacity: 0.6; margin-top: 1rem;">Curated Art & Data</p>
+{% endblock %}
 
+{% block content %}
     <main>
         {% if artwork_files %}
             <div class="gallery-grid">
@@ -46,10 +34,6 @@
             </p>
         {% endif %}
     </main>
+{% endblock %}
 
-    <footer>
-        <p>Artwork Gallery</p>
-    </footer>
-
-</body>
-</html>
+{% block footer %}<p>Artwork Gallery</p>{% endblock %}

--- a/templates/previewImageText.html
+++ b/templates/previewImageText.html
@@ -1,27 +1,15 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Review {{ metadata.title }} &mdash; Artwork Admin</title>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
-    <link href="https://api.fontshare.com/v2/css?f[]=clash-grotesk@200,300,400,500,600,700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
-</head>
-<body class="admin-page" data-root-path="{{ request.scope.get('root_path', '') }}">
-    <header>
-        <h1>Review</h1>
-        <p class="admin-subheading">Curating metadata for artifact</p>
-        <nav class="admin-nav">
-            <a href="{{ review_url }}" class="button secondary">Back to pending list</a>
-            <a href="{{ url_for('read_root') }}" class="button secondary">View Public Gallery</a>
-        </nav>
-    </header>
+{% extends "base_admin.html" %}
 
-    <div class="shader-bg"></div>
+{% block title %}Review {{ metadata.title }} &mdash; Artwork Admin{% endblock %}
+{% block admin_heading %}Review{% endblock %}
+{% block admin_subheading %}Curating metadata for artifact{% endblock %}
 
+{% block admin_nav %}
+<a href="{{ review_url }}" class="button secondary">Back to pending list</a>
+<a href="{{ url_for('read_root') }}" class="button secondary">View Public Gallery</a>
+{% endblock %}
+
+{% block content %}
     <main class="admin-container single">
         <section class="admin-panel">
             <h2>{{ metadata.title }}</h2>
@@ -101,11 +89,9 @@
             </form>
         </section>
     </main>
+{% endblock %}
 
-    <footer>
-        <p>Artwork Gallery Administration</p>
-    </footer>
-
+{% block scripts %}
     <script>
     (function () {
         var ROOT = document.body.dataset.rootPath || '';
@@ -179,5 +165,4 @@
         });
     })();
     </script>
-</body>
-</html>
+{% endblock %}

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -1,26 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <script>(function(){try{var t=localStorage.getItem('az-theme');if(t)document.documentElement.classList.add(t)}catch(e){}})()</script>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Artwork Admin</title>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
-    <link href="https://api.fontshare.com/v2/css?f[]=clash-grotesk@200,300,400,500,600,700&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
-</head>
-<body class="admin-page" data-root-path="{{ request.scope.get('root_path', '') }}">
-    <header>
-        <h1>Administration</h1>
-        <p class="admin-subheading">Gallery curation and artwork management</p>
-        <nav class="admin-nav">
-            <a href="{{ url_for('read_root') }}" class="button secondary">View Public Gallery</a>
-        </nav>
-    </header>
+{% extends "base_admin.html" %}
 
-    <div class="shader-bg"></div>
+{% block title %}Artwork Admin{% endblock %}
 
+{% block content %}
     <nav class="admin-tabs" role="tablist">
         <button class="admin-tab active" role="tab" id="btn-dashboard" aria-selected="true" aria-controls="tab-dashboard" data-tab="dashboard">Dashboard</button>
         <button class="admin-tab" role="tab" id="btn-settings" aria-selected="false" aria-controls="tab-settings" data-tab="settings">Settings</button>
@@ -207,10 +189,9 @@
         </button>
     </nav>
 
-    <footer>
-        <p>Artwork Gallery Administration</p>
-    </footer>
+{% endblock %}
 
+{% block scripts %}
     <script>
     const dropzone = document.getElementById('dropzone');
     const fileInput = document.getElementById('file-input');
@@ -608,5 +589,4 @@
         fileInput?.click();
     });
     </script>
-</body>
-</html>
+{% endblock %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -601,6 +601,26 @@ def test_main_shim_exposes_compat_surface():
         assert hasattr(gallery_app, name), f"main no longer exposes {name}"
 
 
+def test_base_template_on_public_pages(client: TestClient):
+    """Public pages render through base.html: site nav, footer, theme-init."""
+    for path in ("/", "/artwork/test_image.jpg"):
+        response = client.get(path)
+        assert response.status_code == 200
+        assert 'class="site-nav"' in response.text, path
+        assert "<footer>" in response.text, path
+        assert "az-theme" in response.text, path
+
+
+def test_base_template_on_admin_pages(authed_client):
+    """Admin pages render through base_admin.html: admin nav + theme-init."""
+    for path in ("/admin", "/admin/review/test_image.jpg"):
+        response = authed_client.get(path)
+        assert response.status_code == 200
+        assert 'class="admin-nav"' in response.text, path
+        assert 'class="admin-page"' in response.text, path
+        assert "az-theme" in response.text, path
+
+
 def test_all_routes_registered():
     """Every pre-split route path is still registered on main.app."""
     expected = {


### PR DESCRIPTION
## Summary
Adds `templates/base.html` and `templates/base_admin.html` and refactors all four page templates to extend them — no more duplicated head/fonts/theme-init/footers across templates. Public pages gain a shared site-nav (Gallery; the Collections link arrives with the collections feature PR). Rendering is byte-for-byte equivalent where it matters: same classes, same scripts, same design tokens.

Stacked on #65; rebase-merge #64 → #65 first and this reduces to the template refactor.

## Test plan
- 2 new tests assert base-emitted markers (site-nav/footer/theme-init on public pages; admin-nav/admin-page on admin pages)
- Full suite green (44 passed); `manage_sidecars.py validate` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MycKsq6k2TMD2tpurmoVZP
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

