### PR TITLE
fix: post-merge triage of remaining collections review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["dev", "main"]
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
 

--- a/app/ai_metadata.py
+++ b/app/ai_metadata.py
@@ -441,10 +441,10 @@ def _persist_populated_fields(
     the image meanwhile. Writing the pre-call snapshot back would silently
     revert those changes (e.g. flip status back to pending), so re-read the
     sidecar and overlay only what this call produced. Held under the
-    sidecar lock so the read-merge-write cycle is atomic against other
-    writers in this process.
+    sidecar mutation lock (threads + processes) so the read-merge-write
+    cycle is atomic against other writers.
     """
-    with config.sidecar_lock:
+    with sidecars.sidecar_mutation_lock.held():
         fresh = sidecars._load_metadata(image_path)
         for field in applied_fields:
             fresh[field] = metadata[field]
@@ -453,8 +453,11 @@ def _persist_populated_fields(
             fresh["ai_generated"] = True
         else:
             fresh.setdefault("ai_generated", False)
+        # Union only what THIS call generated: the pre-call snapshot's
+        # ai_fields could resurrect provenance a concurrent admin edit
+        # deliberately removed.
         fresh["ai_fields"] = sorted(
-            set(fresh.get("ai_fields", [])) | set(metadata.get("ai_fields", []))
+            set(fresh.get("ai_fields", [])) | set(applied_fields)
         )
         sidecars._write_sidecar(image_path, fresh)
         return fresh

--- a/app/ai_metadata.py
+++ b/app/ai_metadata.py
@@ -405,6 +405,7 @@ def _populate_missing_metadata(
     details = result.get("details", {})
     metadata["ai_details"] = details
 
+    applied_fields: list[str] = []
     if details.get("status") == "success":
         existing_ai_fields = set(metadata.get("ai_fields", []))
         for field in needed_fields:
@@ -412,9 +413,11 @@ def _populate_missing_metadata(
             if field == "tags" and isinstance(val, list) and val:
                 metadata["tags"] = val
                 existing_ai_fields.add("tags")
+                applied_fields.append("tags")
             elif isinstance(val, str) and val:
                 metadata[field] = val
                 existing_ai_fields.add(field)
+                applied_fields.append(field)
         metadata["ai_fields"] = sorted(existing_ai_fields)
         metadata["ai_generated"] = True
     else:
@@ -423,5 +426,35 @@ def _populate_missing_metadata(
     metadata.setdefault("detected_at", time.time())
     metadata.setdefault("status", "pending")
     if persist:
-        sidecars._write_sidecar(image_path, metadata)
+        return _persist_populated_fields(image_path, metadata, applied_fields)
     return metadata
+
+
+def _persist_populated_fields(
+    image_path: Path,
+    metadata: dict[str, Any],
+    applied_fields: list[str],
+) -> dict[str, Any]:
+    """Merge this call's generated fields into the CURRENT sidecar and write.
+
+    The OpenAI request can take many seconds; an admin may approve or edit
+    the image meanwhile. Writing the pre-call snapshot back would silently
+    revert those changes (e.g. flip status back to pending), so re-read the
+    sidecar and overlay only what this call produced. Held under the
+    sidecar lock so the read-merge-write cycle is atomic against other
+    writers in this process.
+    """
+    with config.sidecar_lock:
+        fresh = sidecars._load_metadata(image_path)
+        for field in applied_fields:
+            fresh[field] = metadata[field]
+        fresh["ai_details"] = metadata.get("ai_details", {})
+        if metadata.get("ai_generated"):
+            fresh["ai_generated"] = True
+        else:
+            fresh.setdefault("ai_generated", False)
+        fresh["ai_fields"] = sorted(
+            set(fresh.get("ai_fields", [])) | set(metadata.get("ai_fields", []))
+        )
+        sidecars._write_sidecar(image_path, fresh)
+        return fresh

--- a/app/config.py
+++ b/app/config.py
@@ -66,7 +66,10 @@ logger = logging.getLogger(__name__)
 
 templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
-sidecar_lock = threading.Lock()
+# RLock: writers that must make a read-merge-write cycle atomic (e.g. the
+# AI populate persist path) hold it across _write_sidecar, which acquires
+# it again.
+sidecar_lock = threading.RLock()
 config_lock = threading.Lock()
 
 # Runtime AI configuration, populated by the app lifespan and the admin

--- a/app/curation.py
+++ b/app/curation.py
@@ -14,10 +14,12 @@ Railway volume and are skipped by every image-listing loop.
 """
 
 import copy
+import functools
 import json
 import logging
 import os
 import re
+import threading
 import unicodedata
 from pathlib import Path
 from typing import Any
@@ -37,6 +39,22 @@ SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 _EMPTY_COLLECTIONS: dict[str, Any] = {"version": 1, "collections": []}
 _EMPTY_SERIES: dict[str, Any] = {"version": 1, "series": []}
+
+# Serializes registry read-modify-write cycles so concurrent mutations
+# cannot clobber each other's atomic rename or lose updates. RLock because
+# mutations nest (e.g. upsert_series -> sync_series_mirrors).
+_registry_lock = threading.RLock()
+
+
+def _locked_mutation(fn):
+    """Run a registry mutation under the shared registry lock."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with _registry_lock:
+            return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def slugify(value: str) -> str:
@@ -292,6 +310,7 @@ def collections_for_image(filename: str) -> list[dict[str, Any]]:
 # --- Mutations (single writer; callers hold no locks) ----------------------
 
 
+@_locked_mutation
 def sync_series_mirrors() -> int:
     """Re-sync every sidecar's ``series`` array from the registry.
 
@@ -316,6 +335,7 @@ def sync_series_mirrors() -> int:
     return changed
 
 
+@_locked_mutation
 def migrate_legacy_collections() -> int:
     """v2 -> v3: convert non-empty ``collection`` strings into ``collections``
     slugs plus registry entries. Idempotent; the deprecated string is kept.
@@ -352,6 +372,7 @@ def migrate_legacy_collections() -> int:
     return migrated
 
 
+@_locked_mutation
 def upsert_collection(entry: dict[str, Any]) -> dict[str, Any]:
     """Create or update a collection registry entry."""
     slug = str(entry.get("id") or "").strip() or slugify(str(entry.get("title", "")))
@@ -374,6 +395,13 @@ def upsert_collection(entry: dict[str, Any]) -> dict[str, Any]:
             current = by_slug.get(current, {}).get("parent", "")
 
     existing = by_slug.get(slug)
+    fallback_order = (existing or {}).get("order", len(reg["collections"]))
+    try:
+        order = int(entry.get("order", fallback_order))
+    except (TypeError, ValueError):
+        # null/non-numeric from client JSON keeps the existing/default order
+        # instead of surfacing a 500.
+        order = fallback_order
     clean = {
         "id": slug,
         "title": str(entry.get("title") or (existing or {}).get("title") or slug),
@@ -382,9 +410,7 @@ def upsert_collection(entry: dict[str, Any]) -> dict[str, Any]:
         ),
         "parent": parent,
         "cover": str(entry.get("cover", (existing or {}).get("cover", ""))),
-        "order": int(
-            entry.get("order", (existing or {}).get("order", len(reg["collections"])))
-        ),
+        "order": order,
     }
     if existing:
         reg["collections"] = [
@@ -396,6 +422,7 @@ def upsert_collection(entry: dict[str, Any]) -> dict[str, Any]:
     return clean
 
 
+@_locked_mutation
 def delete_collection(slug: str) -> None:
     """Delete a collection: children re-parent to its parent; sidecar
     memberships are removed. Refuses when it owns series and has no parent
@@ -435,6 +462,7 @@ def delete_collection(slug: str) -> None:
             sidecars._write_sidecar(image_path, data)
 
 
+@_locked_mutation
 def upsert_series(entry: dict[str, Any]) -> dict[str, Any]:
     """Create or update a series registry entry; re-syncs sidecar mirrors."""
     slug = str(entry.get("id") or "").strip() or slugify(str(entry.get("title", "")))
@@ -480,6 +508,7 @@ def upsert_series(entry: dict[str, Any]) -> dict[str, Any]:
     return clean
 
 
+@_locked_mutation
 def delete_series(slug: str) -> None:
     reg = load_series()
     if slug not in _by_id(reg, "series"):

--- a/app/curation.py
+++ b/app/curation.py
@@ -41,18 +41,47 @@ _EMPTY_COLLECTIONS: dict[str, Any] = {"version": 1, "collections": []}
 _EMPTY_SERIES: dict[str, Any] = {"version": 1, "series": []}
 
 # Serializes registry read-modify-write cycles so concurrent mutations
-# cannot clobber each other's atomic rename or lose updates. RLock because
-# mutations nest (e.g. upsert_series -> sync_series_mirrors).
+# cannot clobber each other's atomic rename or lose updates. Two layers:
+# an RLock for threads in this process (mutations nest, e.g. upsert_series
+# -> sync_series_mirrors), plus a POSIX flock on .curation/.lock so a
+# second process (another worker, or manage_sidecars.py running against a
+# live app) is excluded too. Deployment targets are Linux (Railway/local);
+# the file lock fails open with a warning where flock is unavailable.
 _registry_lock = threading.RLock()
+_lock_depth = threading.local()
+_LOCKFILE_NAME = ".lock"
+
+
+def _acquire_registry_file_lock():
+    try:
+        import fcntl
+
+        _curation_dir().mkdir(parents=True, exist_ok=True)
+        # The handle must outlive this function: closing it releases the
+        # flock, which _locked_mutation does after the mutation completes.
+        handle = open(_curation_dir() / _LOCKFILE_NAME, "a")  # noqa: SIM115
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        return handle
+    except Exception as exc:  # pragma: no cover - platform dependent
+        logger.warning("Registry file lock unavailable (%s); proceeding", exc)
+        return None
 
 
 def _locked_mutation(fn):
-    """Run a registry mutation under the shared registry lock."""
+    """Run a registry mutation under the thread and file locks."""
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         with _registry_lock:
-            return fn(*args, **kwargs)
+            depth = getattr(_lock_depth, "value", 0)
+            _lock_depth.value = depth + 1
+            handle = _acquire_registry_file_lock() if depth == 0 else None
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                _lock_depth.value = depth
+                if handle is not None:
+                    handle.close()  # closing releases the flock
 
     return wrapper
 
@@ -396,12 +425,17 @@ def upsert_collection(entry: dict[str, Any]) -> dict[str, Any]:
 
     existing = by_slug.get(slug)
     fallback_order = (existing or {}).get("order", len(reg["collections"]))
-    try:
-        order = int(entry.get("order", fallback_order))
-    except (TypeError, ValueError):
-        # null/non-numeric from client JSON keeps the existing/default order
-        # instead of surfacing a 500.
+    order_value = entry.get("order", fallback_order)
+    if isinstance(order_value, bool):
+        # int(True) == 1 would silently accept a boolean the schema forbids.
         order = fallback_order
+    else:
+        try:
+            order = int(order_value)
+        except (TypeError, ValueError, OverflowError):
+            # null/non-numeric/infinite client JSON keeps the existing or
+            # default order instead of surfacing a 500.
+            order = fallback_order
     clean = {
         "id": slug,
         "title": str(entry.get("title") or (existing or {}).get("title") or slug),
@@ -530,6 +564,7 @@ def _load_registry_schema(name: str) -> dict[str, Any] | None:
         return None
 
 
+@_locked_mutation
 def validate_registries(repair: bool = True) -> dict[str, list[str]]:
     """Validate both registries and referential integrity.
 

--- a/app/curation.py
+++ b/app/curation.py
@@ -19,7 +19,6 @@ import json
 import logging
 import os
 import re
-import threading
 import unicodedata
 from pathlib import Path
 from typing import Any
@@ -40,50 +39,47 @@ SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 _EMPTY_COLLECTIONS: dict[str, Any] = {"version": 1, "collections": []}
 _EMPTY_SERIES: dict[str, Any] = {"version": 1, "series": []}
 
-# Serializes registry read-modify-write cycles so concurrent mutations
-# cannot clobber each other's atomic rename or lose updates. Two layers:
-# an RLock for threads in this process (mutations nest, e.g. upsert_series
-# -> sync_series_mirrors), plus a POSIX flock on .curation/.lock so a
-# second process (another worker, or manage_sidecars.py running against a
-# live app) is excluded too. Deployment targets are Linux (Railway/local);
-# the file lock fails open with a warning where flock is unavailable.
-_registry_lock = threading.RLock()
-_lock_depth = threading.local()
+# Serializes registry read-modify-write cycles across threads AND
+# processes (thread RLock + POSIX flock, see sidecars.TwoLayerLock) so
+# concurrent mutations — including a second worker or manage_sidecars.py
+# against a live app — cannot clobber each other or lose updates.
 _LOCKFILE_NAME = ".lock"
-
-
-def _acquire_registry_file_lock():
-    try:
-        import fcntl
-
-        _curation_dir().mkdir(parents=True, exist_ok=True)
-        # The handle must outlive this function: closing it releases the
-        # flock, which _locked_mutation does after the mutation completes.
-        handle = open(_curation_dir() / _LOCKFILE_NAME, "a")  # noqa: SIM115
-        fcntl.flock(handle, fcntl.LOCK_EX)
-        return handle
-    except Exception as exc:  # pragma: no cover - platform dependent
-        logger.warning("Registry file lock unavailable (%s); proceeding", exc)
-        return None
+_registry_lock = sidecars.TwoLayerLock(lambda: _curation_dir() / _LOCKFILE_NAME)
 
 
 def _locked_mutation(fn):
-    """Run a registry mutation under the thread and file locks."""
+    """Run a registry mutation under the registry lock."""
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        with _registry_lock:
-            depth = getattr(_lock_depth, "value", 0)
-            _lock_depth.value = depth + 1
-            handle = _acquire_registry_file_lock() if depth == 0 else None
-            try:
-                return fn(*args, **kwargs)
-            finally:
-                _lock_depth.value = depth
-                if handle is not None:
-                    handle.close()  # closing releases the flock
+        with _registry_lock.held():
+            return fn(*args, **kwargs)
 
     return wrapper
+
+
+def _mutate_sidecar(image_path: Path, json_path: Path, mutate) -> bool:
+    """Re-read a sidecar under the mutation lock, apply, write if changed.
+
+    Loops that iterate sidecar snapshots must not write those snapshots
+    back later — an AI persist or admin edit landing in between would be
+    overwritten. ``mutate(fresh)`` receives the just-read sidecar and
+    returns True when it changed something worth writing.
+    """
+    with sidecars.sidecar_mutation_lock.held():
+        fresh: dict[str, Any] = {}
+        if json_path.exists():
+            try:
+                loaded = json.loads(json_path.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    fresh = loaded
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Unable to re-read sidecar %s: %s", json_path, exc)
+                return False
+        if mutate(fresh):
+            sidecars._write_sidecar(image_path, fresh)
+            return True
+    return False
 
 
 def slugify(value: str) -> str:
@@ -357,9 +353,16 @@ def sync_series_mirrors() -> int:
         if not json_path.exists():
             continue
         expected = sorted(membership.get(image_path.name, []))
-        if data.get("series", []) != expected:
-            data["series"] = expected
-            sidecars._write_sidecar(image_path, data)
+        if data.get("series", []) == expected:
+            continue  # snapshot pre-filter; re-verified on the fresh read
+
+        def _apply(fresh, expected=expected):
+            if fresh.get("series", []) != expected:
+                fresh["series"] = expected
+                return True
+            return False
+
+        if _mutate_sidecar(image_path, json_path, _apply):
             changed += 1
     return changed
 
@@ -375,26 +378,34 @@ def migrate_legacy_collections() -> int:
     migrated = 0
     registry_changed = False
 
-    for image_path, _json_path, data in _iter_image_sidecars():
+    for image_path, json_path, data in _iter_image_sidecars():
         legacy = str(data.get("collection") or "").strip()
         if not legacy or data.get("collections"):
-            continue
-        slug = slugify(legacy)
-        data["collections"] = [slug]
-        if slug not in by_slug:
-            entry = {
-                "id": slug,
-                "title": legacy,  # first-seen original title wins
-                "description": "",
-                "parent": "",
-                "cover": "",
-                "order": len(reg["collections"]),
-            }
-            reg["collections"].append(entry)
-            by_slug[slug] = entry
-            registry_changed = True
-        sidecars._write_sidecar(image_path, data)
-        migrated += 1
+            continue  # snapshot pre-filter; re-verified on the fresh read
+
+        def _migrate(fresh):
+            nonlocal registry_changed
+            fresh_legacy = str(fresh.get("collection") or "").strip()
+            if not fresh_legacy or fresh.get("collections"):
+                return False
+            slug = slugify(fresh_legacy)
+            fresh["collections"] = [slug]
+            if slug not in by_slug:
+                entry = {
+                    "id": slug,
+                    "title": fresh_legacy,  # first-seen original title wins
+                    "description": "",
+                    "parent": "",
+                    "cover": "",
+                    "order": len(reg["collections"]),
+                }
+                reg["collections"].append(entry)
+                by_slug[slug] = entry
+                registry_changed = True
+            return True
+
+        if _mutate_sidecar(image_path, json_path, _migrate):
+            migrated += 1
 
     if registry_changed:
         save_collections(reg)
@@ -490,10 +501,17 @@ def delete_collection(slug: str) -> None:
         save_series(series_reg)
 
     for image_path, json_path, data in _iter_image_sidecars():
-        memberships = data.get("collections") or []
-        if slug in memberships:
-            data["collections"] = [m for m in memberships if m != slug]
-            sidecars._write_sidecar(image_path, data)
+        if slug not in (data.get("collections") or []):
+            continue  # snapshot pre-filter; re-verified on the fresh read
+
+        def _remove(fresh):
+            memberships = fresh.get("collections") or []
+            if slug in memberships:
+                fresh["collections"] = [m for m in memberships if m != slug]
+                return True
+            return False
+
+        _mutate_sidecar(image_path, json_path, _remove)
 
 
 @_locked_mutation
@@ -644,8 +662,16 @@ def validate_registries(repair: bool = True) -> dict[str, list[str]]:
                 f"{image_path.name}: dangling collection slugs {dangling} dropped"
             )
             if repair:
-                data["collections"] = kept
-                sidecars._write_sidecar(image_path, data)
+
+                def _drop_dangling(fresh):
+                    current = fresh.get("collections") or []
+                    filtered = [m for m in current if m in by_slug]
+                    if filtered != current:
+                        fresh["collections"] = filtered
+                        return True
+                    return False
+
+                _mutate_sidecar(image_path, json_path, _drop_dangling)
 
     if repair:
         repaired = sync_series_mirrors()

--- a/app/factory.py
+++ b/app/factory.py
@@ -23,8 +23,10 @@ async def lifespan(app: FastAPI):
     # Start empty: the watcher task's first cycle runs immediately (off the
     # event loop) and populates the cache; scanning inline here blocked
     # startup — and thus deploy readiness — for a full scan plus any
-    # OpenAI calls. Routes never read this cache directly; they use the
-    # get_pending_files dependency, which performs a fresh scan.
+    # OpenAI calls. Dependency-driven routes use get_pending_files (a fresh
+    # scan); the only direct reader is the regenerate preview path, which
+    # deliberately serves this possibly-stale cache instead of triggering a
+    # scan that could persist other sidecars.
     app.state.pending_images = []
     app.state.watcher_task = asyncio.create_task(watcher._watch_image_directory(app))
     yield

--- a/app/routes_admin.py
+++ b/app/routes_admin.py
@@ -1,5 +1,6 @@
 """Admin dashboard, review, upload, import, config, and curation routes."""
 
+import asyncio
 import copy
 import logging
 import os
@@ -146,11 +147,11 @@ async def mutate_collections(
     payload = body.get("collection") or {}
     try:
         if action in ("create", "update"):
-            entry = curation.upsert_collection(payload)
+            entry = await asyncio.to_thread(curation.upsert_collection, payload)
             return JSONResponse({"status": "ok", "collection": entry})
         if action == "delete":
             slug = str(payload.get("id") or "").strip()
-            curation.delete_collection(slug)
+            await asyncio.to_thread(curation.delete_collection, slug)
             return JSONResponse({"status": "ok", "deleted": slug})
     except KeyError:
         raise HTTPException(
@@ -189,11 +190,11 @@ async def mutate_series(
     payload = body.get("series") or {}
     try:
         if action in ("create", "update", "reorder"):
-            entry = curation.upsert_series(payload)
+            entry = await asyncio.to_thread(curation.upsert_series, payload)
             return JSONResponse({"status": "ok", "series": entry})
         if action == "delete":
             slug = str(payload.get("id") or "").strip()
-            curation.delete_series(slug)
+            await asyncio.to_thread(curation.delete_series, slug)
             return JSONResponse({"status": "ok", "deleted": slug})
     except KeyError:
         raise HTTPException(
@@ -560,13 +561,6 @@ async def update_image_metadata(
         clean_metadata["collections"] = [
             s for s in collection_slugs if s in known_slugs
         ]
-    existing = sidecars._load_metadata(image_path)
-    prior_ai = set(existing.get("ai_fields", []))
-    changed = {
-        f
-        for f in ("title", "description", "caption", "tags")
-        if f in clean_metadata and clean_metadata[f] != existing.get(f)
-    }
     # Fields regenerated via preview arrive as a hidden form field; union
     # them so provenance survives the preview-then-save flow.
     incoming_ai = {
@@ -574,12 +568,29 @@ async def update_image_metadata(
         for f in ai_fields.split(",")
         if f.strip() in ("title", "description", "caption", "tags")
     }
-    existing["ai_fields"] = sorted((prior_ai - changed) | incoming_ai)
-    if incoming_ai or sidecars._coerce_bool(ai_generated):
-        existing["ai_generated"] = True
-    existing.update(clean_metadata)
-    existing["status"] = "approved"
-    sidecars._write_sidecar(image_path, existing)
+    mark_generated = bool(incoming_ai) or sidecars._coerce_bool(ai_generated)
+
+    def _save_metadata() -> None:
+        # Read-modify-write under the sidecar mutation lock (and off the
+        # event loop): a concurrent AI persist or curation sync must not
+        # land between our read and write, and the file lock must never
+        # block request handling.
+        with sidecars.sidecar_mutation_lock.held():
+            existing = sidecars._load_metadata(image_path)
+            prior_ai = set(existing.get("ai_fields", []))
+            changed = {
+                f
+                for f in ("title", "description", "caption", "tags")
+                if f in clean_metadata and clean_metadata[f] != existing.get(f)
+            }
+            existing["ai_fields"] = sorted((prior_ai - changed) | incoming_ai)
+            if mark_generated:
+                existing["ai_generated"] = True
+            existing.update(clean_metadata)
+            existing["status"] = "approved"
+            sidecars._write_sidecar(image_path, existing)
+
+    await asyncio.to_thread(_save_metadata)
 
     return RedirectResponse(
         url=request.url_for("review_added_files"),
@@ -598,7 +609,7 @@ async def unapprove_image(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Image not found"
         )
-    sidecars._set_status_sidecar(image_path, "pending")
+    await asyncio.to_thread(sidecars._set_status_sidecar, image_path, "pending")
     return JSONResponse({"status": "ok", "image": image_name, "new_status": "pending"})
 
 

--- a/app/routes_admin.py
+++ b/app/routes_admin.py
@@ -156,7 +156,7 @@ async def mutate_collections(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Collection not found"
         )
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
@@ -346,7 +346,13 @@ async def regenerate_ai_metadata(
             logger.exception("Failed to regenerate metadata for %s", fname)
             errors.append({"name": fname, "error": "Metadata regeneration failed"})
 
-    pending = await watcher.refresh_pending_files(request)
+    if preview:
+        # A preview must not write anything — refresh_pending_files scans,
+        # and the scan may AI-populate and persist OTHER pending sidecars.
+        # Serve the cached list instead (the watcher keeps it fresh).
+        pending = getattr(request.app.state, "pending_images", [])
+    else:
+        pending = await watcher.refresh_pending_files(request)
     return JSONResponse({"updated": updated, "errors": errors, "pending": pending})
 
 

--- a/app/sidecars.py
+++ b/app/sidecars.py
@@ -4,8 +4,9 @@ import json
 import logging
 import os
 import tempfile
+import threading
 import time
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,61 @@ logger = logging.getLogger(__name__)
 # Defined in config (the lowest layer) so every module can use it;
 # aliased here because callers and the main shim import it from sidecars.
 _coerce_bool = config._coerce_bool
+
+
+class TwoLayerLock:
+    """Thread RLock plus a POSIX flock, re-entrant per thread.
+
+    Serializes read-modify-write cycles both across threads in this
+    process and across processes sharing the same IMAGES_DIR (a second
+    worker, or manage_sidecars.py run against a live app). The file lock
+    fails open with a warning where flock is unavailable; deployment
+    targets are Linux (Railway/local).
+    """
+
+    def __init__(self, lockfile_getter):
+        self._rlock = threading.RLock()
+        self._depth = threading.local()
+        self._lockfile_getter = lockfile_getter
+
+    def _acquire_file(self):
+        handle = None
+        try:
+            import fcntl
+
+            path = self._lockfile_getter()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # The handle must outlive this method: closing it releases the
+            # flock, which held() does once the critical section ends.
+            handle = open(path, "a")  # noqa: SIM115
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            return handle
+        except Exception as exc:  # pragma: no cover - platform dependent
+            if handle is not None:
+                handle.close()
+            logger.warning("File lock unavailable (%s); proceeding", exc)
+            return None
+
+    @contextmanager
+    def held(self):
+        with self._rlock:
+            depth = getattr(self._depth, "value", 0)
+            self._depth.value = depth + 1
+            handle = self._acquire_file() if depth == 0 else None
+            try:
+                yield
+            finally:
+                self._depth.value = depth
+                if handle is not None:
+                    handle.close()  # closing releases the flock
+
+
+# Guards every sidecar read-modify-write cycle (AI persist merge, status
+# flips, metadata saves, curation mirror/membership loops). The lockfile
+# lives under .curation/, which image-listing loops already skip.
+sidecar_mutation_lock = TwoLayerLock(
+    lambda: config.IMAGES_DIR / ".curation" / ".sidecars.lock"
+)
 
 
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
@@ -200,18 +256,19 @@ def _write_sidecar(image_path: Path, metadata: dict[str, Any]) -> None:
 def _set_status_sidecar(image_path: Path, new_status: str) -> None:
     safe_image_path = _resolve_image_path(image_path.name)
     json_path = safe_image_path.with_suffix(".json")
-    data: dict[str, Any] = {}
-    if json_path.exists():
-        with suppress(json.JSONDecodeError, OSError):
-            data = json.loads(json_path.read_text(encoding="utf-8"))
-    data["status"] = new_status
-    data.setdefault("title", "")
-    data.setdefault("description", "")
-    data.setdefault("ai_generated", False)
-    if not isinstance(data.get("ai_details"), dict):
-        data["ai_details"] = {}
-    data.setdefault("detected_at", time.time())
-    _write_sidecar(image_path, data)
+    with sidecar_mutation_lock.held():
+        data: dict[str, Any] = {}
+        if json_path.exists():
+            with suppress(json.JSONDecodeError, OSError):
+                data = json.loads(json_path.read_text(encoding="utf-8"))
+        data["status"] = new_status
+        data.setdefault("title", "")
+        data.setdefault("description", "")
+        data.setdefault("ai_generated", False)
+        if not isinstance(data.get("ai_details"), dict):
+            data["ai_details"] = {}
+        data.setdefault("detected_at", time.time())
+        _write_sidecar(image_path, data)
 
 
 def _load_metadata(image_path: Path) -> dict[str, Any]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -727,6 +727,51 @@ def test_upsert_collection_null_order_falls_back(tmp_path, monkeypatch):
         {"id": "flora", "title": "Flora", "order": "not-a-number"}
     )
     assert isinstance(entry["order"], int)
+    # JSON booleans coerce via int(True) == 1; the schema forbids them.
+    entry = gallery_app.curation.upsert_collection(
+        {"id": "flora", "title": "Flora", "order": 7}
+    )
+    entry = gallery_app.curation.upsert_collection(
+        {"id": "flora", "title": "Flora", "order": True}
+    )
+    assert entry["order"] == 7
+    # 1e999 decodes to infinity; int(inf) raises OverflowError.
+    entry = gallery_app.curation.upsert_collection(
+        {"id": "flora", "title": "Flora", "order": float("inf")}
+    )
+    assert entry["order"] == 7
+
+
+def test_ai_persist_merges_concurrent_sidecar_changes(monkeypatch, tmp_path):
+    """An admin change made during the (slow) AI call must survive the
+    persist — the pre-call snapshot must not be written back wholesale."""
+    image_root = _make_curation_root(tmp_path, monkeypatch)
+    _add_image(image_root, "a.jpg", title="", status="pending")
+    sidecar = image_root / "a.json"
+
+    def approving_request(path, meta, fields):
+        # Simulate an admin approving the image while the AI call is in
+        # flight: the on-disk sidecar changes under the caller's snapshot.
+        data = json.loads(sidecar.read_text())
+        data["status"] = "approved"
+        data["description"] = "Edited during AI call"
+        sidecar.write_text(json.dumps(data))
+        return {"title": "AI Title", "details": {"status": "success"}}
+
+    monkeypatch.setattr(
+        gallery_app.ai_metadata, "_request_openai_metadata", approving_request
+    )
+
+    meta = gallery_app.sidecars._load_metadata(image_root / "a.jpg")
+    result = gallery_app.ai_metadata._populate_missing_metadata(
+        image_root / "a.jpg", meta, only_fields=["title"], persist=True
+    )
+
+    saved = json.loads(sidecar.read_text())
+    assert saved["title"] == "AI Title"  # this call's field applied
+    assert saved["status"] == "approved"  # concurrent approval survives
+    assert saved["description"] == "Edited during AI call"
+    assert result["status"] == "approved"  # caller sees the merged truth
 
 
 def test_preview_regenerate_does_not_trigger_refresh(monkeypatch, tmp_path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -751,10 +751,12 @@ def test_ai_persist_merges_concurrent_sidecar_changes(monkeypatch, tmp_path):
 
     def approving_request(path, meta, fields):
         # Simulate an admin approving the image while the AI call is in
-        # flight: the on-disk sidecar changes under the caller's snapshot.
+        # flight: the on-disk sidecar changes under the caller's snapshot —
+        # including deliberately clearing AI provenance for a hand edit.
         data = json.loads(sidecar.read_text())
         data["status"] = "approved"
         data["description"] = "Edited during AI call"
+        data["ai_fields"] = []
         sidecar.write_text(json.dumps(data))
         return {"title": "AI Title", "details": {"status": "success"}}
 
@@ -771,6 +773,9 @@ def test_ai_persist_merges_concurrent_sidecar_changes(monkeypatch, tmp_path):
     assert saved["title"] == "AI Title"  # this call's field applied
     assert saved["status"] == "approved"  # concurrent approval survives
     assert saved["description"] == "Edited during AI call"
+    # Only this call's provenance is added; the concurrent edit's cleared
+    # ai_fields are not resurrected from the pre-call snapshot.
+    assert saved["ai_fields"] == ["title"]
     assert result["status"] == "approved"  # caller sees the merged truth
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -716,6 +716,68 @@ def test_manage_sidecars_cli_honors_images_dir_env(tmp_path):
     assert (image_root / ".curation" / "collections.json").exists()
 
 
+def test_upsert_collection_null_order_falls_back(tmp_path, monkeypatch):
+    """A null/non-numeric order from client JSON must not raise."""
+    _make_curation_root(tmp_path, monkeypatch)
+    entry = gallery_app.curation.upsert_collection(
+        {"id": "flora", "title": "Flora", "order": None}
+    )
+    assert isinstance(entry["order"], int)
+    entry = gallery_app.curation.upsert_collection(
+        {"id": "flora", "title": "Flora", "order": "not-a-number"}
+    )
+    assert isinstance(entry["order"], int)
+
+
+def test_preview_regenerate_does_not_trigger_refresh(monkeypatch, tmp_path):
+    """A preview request must not run the pending refresh, whose scan can
+    AI-populate and persist other pending sidecars."""
+    image_root = _make_curation_root(tmp_path, monkeypatch)
+    _add_image(image_root, "a.jpg", status="pending")
+    monkeypatch.setattr(
+        gallery_app.ai_metadata,
+        "_populate_missing_metadata",
+        lambda path, meta, only_fields=None, persist=True: {
+            **meta,
+            "title": "AI Title",
+            "ai_details": {"status": "success"},
+        },
+    )
+    refresh_calls = []
+
+    async def recording_refresh(request):
+        refresh_calls.append(True)
+        return []
+
+    monkeypatch.setattr(gallery_app.watcher, "refresh_pending_files", recording_refresh)
+
+    response = asyncio.run(
+        gallery_app.regenerate_ai_metadata(
+            _regen_request(
+                {
+                    "images": ["a.jpg"],
+                    "fields": ["title"],
+                    "force": True,
+                    "preview": True,
+                }
+            ),
+            _=None,
+        )
+    )
+    payload = json.loads(response.body)
+    assert payload["updated"][0]["preview"] is True
+    assert refresh_calls == []
+
+    # Non-preview still refreshes.
+    asyncio.run(
+        gallery_app.regenerate_ai_metadata(
+            _regen_request({"images": ["a.jpg"], "fields": ["title"], "force": True}),
+            _=None,
+        )
+    )
+    assert refresh_calls == [True]
+
+
 def test_series_requires_existing_collection(tmp_path, monkeypatch):
     _make_curation_root(tmp_path, monkeypatch)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
Addresses the inline Copilot/CodeQL comments that landed on #67 between its branch update and merge (they were missed in that round; each thread on #67 now has a reply pointing here). Verified first: the two CodeQL path-injection alerts and the cover-sanitization comment were already fixed by the containment work and are closed on dev — the three real leftovers are fixed here:

- **`order` 500**: `upsert_collection` parses `order` defensively (null/non-numeric keeps existing/default) and the collections route returns 400 on `TypeError`, matching the series route.
- **Registry write races**: all six registry mutations (upsert/delete collection/series, migration, mirror sync) run under a shared RLock, so concurrent read-modify-write cycles can't lose updates.
- **Preview purity**: preview regeneration no longer triggers the pending refresh — the refresh's scan can AI-populate and *persist other pending sidecars*, quietly violating the preview-persists-nothing guarantee. Previews serve the watcher-maintained cache instead.

Bonus: `ci.yml` now declares least-privilege `permissions: contents: read`, clearing the five open `actions/missing-workflow-permissions` CodeQL alerts (pre-existing, unrelated to this stack).

Stacked on #70 — merge that first and this reduces to the four files above.

## Test plan
- New tests: null/non-numeric order falls back; preview regen never calls the refresh while non-preview still does
- Full suite: 68 passed; ruff/black/prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MycKsq6k2TMD2tpurmoVZP
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

