### PR TITLE
fix(deps): unbreak dependency resolution on dev + gitignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ data/
 final_test.log
 logs/
 .agent-harness/
+/uv.lock

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ click==8.2.1
 coverage==7.15.4
 dnspython==2.7.0
 email-validator==2.2.0
-fastapi==0.1.17
+fastapi==0.116.1
 fastapi-cli==0.0.8
 fastapi-cloud-cli==0.1.4
 greenlet==3.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ click==8.2.1
 coverage==7.15.4
 dnspython==2.7.0
 email-validator==2.2.0
-fastapi==0.116.1
+fastapi==0.1.17
 fastapi-cli==0.0.8
 fastapi-cloud-cli==0.1.4
 greenlet==3.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ click==8.2.1
 coverage==7.15.4
 dnspython==2.7.0
 email-validator==2.2.0
-fastapi==0.116.1
+fastapi==0.133.0
 fastapi-cli==0.0.8
 fastapi-cloud-cli==0.1.4
 greenlet==3.5.5
@@ -63,7 +63,7 @@ stevedore==5.9.0
 typer==0.16.0
 types-pillow==10.2.0.20240822
 typing-extensions==4.14.1
-typing-inspection==0.4.1
+typing-inspection==0.4.2
 ujson==5.13.0
 urllib3==2.7.0
 uvicorn==0.35.0


### PR DESCRIPTION
## Summary

`dev` currently cannot install its own dependencies. Dependabot #60 bumped `starlette` 0.47.3 → 1.3.1 without bumping `fastapi`, which leaves the pin set unresolvable:

```
The user requested starlette==1.3.1
fastapi 0.116.1 depends on starlette<0.48.0 and >=0.40.0
ERROR: ResolutionImpossible
```

This blocks **Tests & coverage** and **Type check** on every branch that picks up current `dev`.

## Changes

| Pin | Before | After | Why |
| --- | --- | --- | --- |
| `fastapi` | 0.116.1 | 0.133.0 | First release that drops the `starlette` upper bound (`starlette>=0.40.0`) |
| `typing-inspection` | 0.4.1 | 0.4.2 | Required by fastapi 0.133.0 (`>=0.4.2`) |
| `.gitignore` | — | `+/uv.lock` | Keep `uv.lock` out of the repo |

**Why bump fastapi instead of reverting starlette:** starlette 1.3.1 adds `FormParser` `max_fields` / `max_part_size` enforcement — multipart hardening that directly covers the `/admin/upload` path. Reverting would drop it.

**Why 0.133.0 and not latest (0.141.1):** 0.133.0 is the minimal bump that resolves. Going to `typing-inspection` 0.4.3+ would additionally force `typing-extensions>=4.15.0` and `Python>=3.10`, cascading more pins for no benefit.

## Test plan

Run against the exact CI commands from `.github/workflows/ci.yml`:

- [x] `pip install -r requirements.txt` — resolves clean (previously `ResolutionImpossible`)
- [x] `pytest tests/test_main.py -q` — **69 passed**
- [x] `mypy main.py --ignore-missing-imports --no-strict-optional` — Success, no issues
- [x] `import main` — app loads ("Artwork Gallery")

## Notes

The two earlier commits on this branch are kept for history: the original `uv pip install` run resolved `fastapi` to `0.1.17` (a 2018 release that imports the long-removed `pydantic.Schema`), reverted in `57fbce7`.

Once this merges, #61 and #62 need to be updated from `dev` to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Bzi1hFicZpmyYCeH3rvH5
