### PR TITLE
feat(seo): add robots.txt, sitemap.xml, and canonical link tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ MY_OPENAI_API_KEY=
 OPENAI_IMAGE_METADATA_MODEL=gpt-5.6-luna
 OPENAI_TIMEOUT_SECONDS=30
 
+# Canonical site URL for SEO (sitemap, robots.txt, canonical link tags)
+# SITE_URL=https://artazzen.com
+
 # Upload limit
 MAX_UPLOAD_SIZE_MB=50
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,11 +257,11 @@ main (production)          ← deployed to Railway production environment
 
 ### Branch Roles
 
-| Branch                                 | Purpose                   | Deploys To                            | Protected                               |
-| -------------------------------------- | ------------------------- | ------------------------------------- | --------------------------------------- |
-| `main`                                 | Production-ready code     | Railway production                    | Yes — PR required, all threads resolved |
-| `dev`                                  | Integration and staging   | Railway staging (when configured)     | Yes — PR required                       |
-| `feat/*`, `fix/*`, `docs/*`, `chore/*` | Short-lived work branches | Railway PR previews (when configured) | No                                      |
+| Branch                                 | Purpose                   | Deploys To                        | Protected                               |
+| -------------------------------------- | ------------------------- | --------------------------------- | --------------------------------------- |
+| `main`                                 | Production-ready code     | Railway production                | Yes — PR required, all threads resolved |
+| `dev`                                  | Integration and staging   | Railway staging (when configured) | Yes — PR required                       |
+| `feat/*`, `fix/*`, `docs/*`, `chore/*` | Short-lived work branches | Railway PR previews               | No                                      |
 
 ### Rules
 
@@ -360,7 +360,7 @@ Railway can spin up isolated environments for each pull request, giving reviewer
 | `ADMIN_USERNAME`              | `admin`                                                      | `admin`                       |
 | `ADMIN_PASSWORD`              | production secret                                            | shared test password          |
 | `MY_OPENAI_API_KEY`           | production key                                               | test key or unset             |
-| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-4o-mini`                                                | `gpt-4o-mini`                 |
+| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-5.6-luna`                                               | `gpt-5.6-luna`                |
 | `MAX_UPLOAD_SIZE_MB`          | `50`                                                         | `50`                          |
 | `PORT`                        | set by Railway                                               | set by Railway                |
 
@@ -581,7 +581,7 @@ See `.env.example` for the full list. Key vars:
 | `ADMIN_USERNAME`              | `admin`                | Basic auth username for admin                                          |
 | `ADMIN_PASSWORD`              | _(none)_               | Basic auth password (**required** for admin)                           |
 | `MY_OPENAI_API_KEY`           | _(none)_               | OpenAI API key for AI metadata                                         |
-| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-4o-mini`          | Model for AI descriptions                                              |
+| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-5.6-luna`         | Model for AI descriptions                                              |
 | `OPENAI_TIMEOUT_SECONDS`      | `30`                   | Timeout for OpenAI calls                                               |
 | `MAX_UPLOAD_SIZE_MB`          | `50`                   | Max upload file size                                                   |
 | `PORT`                        | _(uvicorn default)_    | Server port (set by Railway)                                           |
@@ -599,7 +599,14 @@ Follow the four Karpathy principles for LLM-assisted coding:
 
 1. **Branch** from `dev` using the appropriate prefix (`feat/`, `fix/`, `docs/`, `chore/`).
 2. **Develop** incrementally — commit often with clear messages.
-3. **Validate** — run `pytest` and `python manage_sidecars.py validate` before pushing.
+3. **Validate** — run the CI checks locally before pushing:
+   ```bash
+   pytest tests/test_main.py -q                          # Tests
+   python manage_sidecars.py validate                     # Sidecar JSON
+   ruff check .                                           # Lint
+   black --check --target-version py311 .                 # Format (Python)
+   npx --yes prettier --check "**/*.{md,yml,yaml,json}"   # Format (docs/config)
+   ```
 4. **Push** and open a PR targeting `dev`. Mark as draft if still in progress.
 5. **Review** — wait for CodeQL and Copilot checks; respond to every comment thread.
 6. **Merge** via rebase or merge commit (squash is not allowed by ruleset).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,6 +458,8 @@ Layering (no cycles): `config → sidecars → ai_metadata → curation → watc
 | Path                           | Method   | Purpose                                                 |
 | ------------------------------ | -------- | ------------------------------------------------------- |
 | `/`                            | GET      | Public gallery                                          |
+| `/robots.txt`                  | GET      | SEO: robots.txt with sitemap directive                  |
+| `/sitemap.xml`                 | GET      | SEO: dynamic XML sitemap (approved artworks+collections)|
 | `/artwork/{image_filename}`    | GET      | Single artwork detail                                   |
 | `/admin`                       | GET      | Admin dashboard                                         |
 | `/admin/review`                | GET      | Review queue                                            |
@@ -573,6 +575,7 @@ See `.env.example` for the full list. Key vars:
 
 | Variable                      | Default             | Description                                                            |
 | ----------------------------- | ------------------- | ---------------------------------------------------------------------- |
+| `SITE_URL`                    | `https://artazzen.com` | Canonical site URL for SEO (sitemap, robots.txt, canonical tags)    |
 | `IMAGES_DIR`                  | `Static/images`     | Image storage path. Set to `/data/images` on Railway                   |
 | `IMPORT_ROOT`                 | `imports`           | Only server directory allowed as a source for admin filesystem imports |
 | `ADMIN_USERNAME`              | `admin`             | Basic auth username for admin                                          |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,11 +257,11 @@ main (production)          ← deployed to Railway production environment
 
 ### Branch Roles
 
-| Branch                                 | Purpose                   | Deploys To                        | Protected                               |
-| -------------------------------------- | ------------------------- | --------------------------------- | --------------------------------------- |
-| `main`                                 | Production-ready code     | Railway production                | Yes — PR required, all threads resolved |
-| `dev`                                  | Integration and staging   | Railway staging (when configured) | Yes — PR required                       |
-| `feat/*`, `fix/*`, `docs/*`, `chore/*` | Short-lived work branches | Railway PR previews               | No                                      |
+| Branch                                 | Purpose                   | Deploys To                            | Protected                               |
+| -------------------------------------- | ------------------------- | ------------------------------------- | --------------------------------------- |
+| `main`                                 | Production-ready code     | Railway production                    | Yes — PR required, all threads resolved |
+| `dev`                                  | Integration and staging   | Railway staging (when configured)     | Yes — PR required                       |
+| `feat/*`, `fix/*`, `docs/*`, `chore/*` | Short-lived work branches | Railway PR previews (when configured) | No                                      |
 
 ### Rules
 
@@ -360,7 +360,7 @@ Railway can spin up isolated environments for each pull request, giving reviewer
 | `ADMIN_USERNAME`              | `admin`                                                      | `admin`                       |
 | `ADMIN_PASSWORD`              | production secret                                            | shared test password          |
 | `MY_OPENAI_API_KEY`           | production key                                               | test key or unset             |
-| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-5.6-luna`                                               | `gpt-5.6-luna`                |
+| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-4o-mini`                                                | `gpt-4o-mini`                 |
 | `MAX_UPLOAD_SIZE_MB`          | `50`                                                         | `50`                          |
 | `PORT`                        | set by Railway                                               | set by Railway                |
 
@@ -455,26 +455,26 @@ Layering (no cycles): `config → sidecars → ai_metadata → curation → watc
 
 ### Route Map
 
-| Path                           | Method   | Purpose                                                 |
-| ------------------------------ | -------- | ------------------------------------------------------- |
-| `/`                            | GET      | Public gallery                                          |
-| `/robots.txt`                  | GET      | SEO: robots.txt with sitemap directive                  |
-| `/sitemap.xml`                 | GET      | SEO: dynamic XML sitemap (approved artworks+collections)|
-| `/artwork/{image_filename}`    | GET      | Single artwork detail                                   |
-| `/admin`                       | GET      | Admin dashboard                                         |
-| `/admin/review`                | GET      | Review queue                                            |
-| `/admin/review/{image_name}`   | GET      | Review specific image                                   |
-| `/admin/api/new-files`         | GET      | JSON: pending files                                     |
-| `/admin/upload`                | POST     | Upload artwork                                          |
-| `/admin/import-path`           | POST     | Import from filesystem                                  |
-| `/admin/metadata/{image_name}` | POST     | Save image metadata                                     |
-| `/collections`                 | GET      | Collections index                                       |
-| `/collections/{slug}`          | GET      | Collection page (series strips + grid)                  |
-| `/admin/api/collections`       | GET/POST | Collections registry CRUD                               |
-| `/admin/api/series`            | GET/POST | Series registry CRUD                                    |
-| `/admin/config`                | GET/POST | AI config CRUD                                          |
-| `/admin/config/reset`          | POST     | Reset AI config                                         |
-| `/admin/ai/regenerate`         | POST     | AI regeneration (supports `fields`, `force`, `preview`) |
+| Path                           | Method   | Purpose                                                  |
+| ------------------------------ | -------- | -------------------------------------------------------- |
+| `/`                            | GET      | Public gallery                                           |
+| `/robots.txt`                  | GET      | SEO: robots.txt with sitemap directive                   |
+| `/sitemap.xml`                 | GET      | SEO: dynamic XML sitemap (approved artworks+collections) |
+| `/artwork/{image_filename}`    | GET      | Single artwork detail                                    |
+| `/admin`                       | GET      | Admin dashboard                                          |
+| `/admin/review`                | GET      | Review queue                                             |
+| `/admin/review/{image_name}`   | GET      | Review specific image                                    |
+| `/admin/api/new-files`         | GET      | JSON: pending files                                      |
+| `/admin/upload`                | POST     | Upload artwork                                           |
+| `/admin/import-path`           | POST     | Import from filesystem                                   |
+| `/admin/metadata/{image_name}` | POST     | Save image metadata                                      |
+| `/collections`                 | GET      | Collections index                                        |
+| `/collections/{slug}`          | GET      | Collection page (series strips + grid)                   |
+| `/admin/api/collections`       | GET/POST | Collections registry CRUD                                |
+| `/admin/api/series`            | GET/POST | Series registry CRUD                                     |
+| `/admin/config`                | GET/POST | AI config CRUD                                           |
+| `/admin/config/reset`          | POST     | Reset AI config                                          |
+| `/admin/ai/regenerate`         | POST     | AI regeneration (supports `fields`, `force`, `preview`)  |
 
 ## Tech Stack
 
@@ -573,18 +573,18 @@ Admin routes (`/admin/*`) are protected by HTTP Basic Auth.
 
 See `.env.example` for the full list. Key vars:
 
-| Variable                      | Default             | Description                                                            |
-| ----------------------------- | ------------------- | ---------------------------------------------------------------------- |
-| `SITE_URL`                    | `https://artazzen.com` | Canonical site URL for SEO (sitemap, robots.txt, canonical tags)    |
-| `IMAGES_DIR`                  | `Static/images`     | Image storage path. Set to `/data/images` on Railway                   |
-| `IMPORT_ROOT`                 | `imports`           | Only server directory allowed as a source for admin filesystem imports |
-| `ADMIN_USERNAME`              | `admin`             | Basic auth username for admin                                          |
-| `ADMIN_PASSWORD`              | _(none)_            | Basic auth password (**required** for admin)                           |
-| `MY_OPENAI_API_KEY`           | _(none)_            | OpenAI API key for AI metadata                                         |
-| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-5.6-luna`      | Model for AI descriptions                                              |
-| `OPENAI_TIMEOUT_SECONDS`      | `30`                | Timeout for OpenAI calls                                               |
-| `MAX_UPLOAD_SIZE_MB`          | `50`                | Max upload file size                                                   |
-| `PORT`                        | _(uvicorn default)_ | Server port (set by Railway)                                           |
+| Variable                      | Default                | Description                                                            |
+| ----------------------------- | ---------------------- | ---------------------------------------------------------------------- |
+| `SITE_URL`                    | `https://artazzen.com` | Canonical site URL for SEO (sitemap, robots.txt, canonical tags)       |
+| `IMAGES_DIR`                  | `Static/images`        | Image storage path. Set to `/data/images` on Railway                   |
+| `IMPORT_ROOT`                 | `imports`              | Only server directory allowed as a source for admin filesystem imports |
+| `ADMIN_USERNAME`              | `admin`                | Basic auth username for admin                                          |
+| `ADMIN_PASSWORD`              | _(none)_               | Basic auth password (**required** for admin)                           |
+| `MY_OPENAI_API_KEY`           | _(none)_               | OpenAI API key for AI metadata                                         |
+| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-4o-mini`          | Model for AI descriptions                                              |
+| `OPENAI_TIMEOUT_SECONDS`      | `30`                   | Timeout for OpenAI calls                                               |
+| `MAX_UPLOAD_SIZE_MB`          | `50`                   | Max upload file size                                                   |
+| `PORT`                        | _(uvicorn default)_    | Server port (set by Railway)                                           |
 
 ## Core Principles
 
@@ -599,14 +599,7 @@ Follow the four Karpathy principles for LLM-assisted coding:
 
 1. **Branch** from `dev` using the appropriate prefix (`feat/`, `fix/`, `docs/`, `chore/`).
 2. **Develop** incrementally — commit often with clear messages.
-3. **Validate** — run the CI checks locally before pushing:
-   ```bash
-   pytest tests/test_main.py -q                          # Tests
-   python manage_sidecars.py validate                     # Sidecar JSON
-   ruff check .                                           # Lint
-   black --check --target-version py311 .                 # Format (Python)
-   npx --yes prettier --check "**/*.{md,yml,yaml,json}"   # Format (docs/config)
-   ```
+3. **Validate** — run `pytest` and `python manage_sidecars.py validate` before pushing.
 4. **Push** and open a PR targeting `dev`. Mark as draft if still in progress.
 5. **Review** — wait for CodeQL and Copilot checks; respond to every comment thread.
 6. **Merge** via rebase or merge commit (squash is not allowed by ruleset).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ Layering (no cycles): `config → sidecars → ai_metadata → curation → watc
 | Path                           | Method   | Purpose                                                 |
 | ------------------------------ | -------- | ------------------------------------------------------- |
 | `/`                            | GET      | Public gallery                                          |
+| `/robots.txt`                  | GET      | SEO: robots.txt with sitemap directive                  |
+| `/sitemap.xml`                 | GET      | SEO: dynamic XML sitemap (approved artworks+collections)|
 | `/artwork/{image_filename}`    | GET      | Single artwork detail                                   |
 | `/admin`                       | GET      | Admin dashboard                                         |
 | `/admin/review`                | GET      | Review queue                                            |
@@ -183,6 +185,7 @@ See `.env.example` for the full list. Key vars:
 
 | Variable                      | Default             | Description                                                            |
 | ----------------------------- | ------------------- | ---------------------------------------------------------------------- |
+| `SITE_URL`                    | `https://artazzen.com` | Canonical site URL for SEO (sitemap, robots.txt, canonical tags)    |
 | `IMAGES_DIR`                  | `Static/images`     | Image storage path. Set to `/data/images` on Railway                   |
 | `IMPORT_ROOT`                 | `imports`           | Only server directory allowed as a source for admin filesystem imports |
 | `ADMIN_USERNAME`              | `admin`             | Basic auth username for admin                                          |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,26 +65,26 @@ Layering (no cycles): `config → sidecars → ai_metadata → curation → watc
 
 ### Route Map
 
-| Path                           | Method   | Purpose                                                 |
-| ------------------------------ | -------- | ------------------------------------------------------- |
-| `/`                            | GET      | Public gallery                                          |
-| `/robots.txt`                  | GET      | SEO: robots.txt with sitemap directive                  |
-| `/sitemap.xml`                 | GET      | SEO: dynamic XML sitemap (approved artworks+collections)|
-| `/artwork/{image_filename}`    | GET      | Single artwork detail                                   |
-| `/admin`                       | GET      | Admin dashboard                                         |
-| `/admin/review`                | GET      | Review queue                                            |
-| `/admin/review/{image_name}`   | GET      | Review specific image                                   |
-| `/admin/api/new-files`         | GET      | JSON: pending files                                     |
-| `/admin/upload`                | POST     | Upload artwork                                          |
-| `/admin/import-path`           | POST     | Import from filesystem                                  |
-| `/admin/metadata/{image_name}` | POST     | Save image metadata                                     |
-| `/collections`                 | GET      | Collections index                                       |
-| `/collections/{slug}`          | GET      | Collection page (series strips + grid)                  |
-| `/admin/api/collections`       | GET/POST | Collections registry CRUD                               |
-| `/admin/api/series`            | GET/POST | Series registry CRUD                                    |
-| `/admin/config`                | GET/POST | AI config CRUD                                          |
-| `/admin/config/reset`          | POST     | Reset AI config                                         |
-| `/admin/ai/regenerate`         | POST     | AI regeneration (supports `fields`, `force`, `preview`) |
+| Path                           | Method   | Purpose                                                  |
+| ------------------------------ | -------- | -------------------------------------------------------- |
+| `/`                            | GET      | Public gallery                                           |
+| `/robots.txt`                  | GET      | SEO: robots.txt with sitemap directive                   |
+| `/sitemap.xml`                 | GET      | SEO: dynamic XML sitemap (approved artworks+collections) |
+| `/artwork/{image_filename}`    | GET      | Single artwork detail                                    |
+| `/admin`                       | GET      | Admin dashboard                                          |
+| `/admin/review`                | GET      | Review queue                                             |
+| `/admin/review/{image_name}`   | GET      | Review specific image                                    |
+| `/admin/api/new-files`         | GET      | JSON: pending files                                      |
+| `/admin/upload`                | POST     | Upload artwork                                           |
+| `/admin/import-path`           | POST     | Import from filesystem                                   |
+| `/admin/metadata/{image_name}` | POST     | Save image metadata                                      |
+| `/collections`                 | GET      | Collections index                                        |
+| `/collections/{slug}`          | GET      | Collection page (series strips + grid)                   |
+| `/admin/api/collections`       | GET/POST | Collections registry CRUD                                |
+| `/admin/api/series`            | GET/POST | Series registry CRUD                                     |
+| `/admin/config`                | GET/POST | AI config CRUD                                           |
+| `/admin/config/reset`          | POST     | Reset AI config                                          |
+| `/admin/ai/regenerate`         | POST     | AI regeneration (supports `fields`, `force`, `preview`)  |
 
 ## Tech Stack
 
@@ -183,18 +183,18 @@ Admin routes (`/admin/*`) are protected by HTTP Basic Auth.
 
 See `.env.example` for the full list. Key vars:
 
-| Variable                      | Default             | Description                                                            |
-| ----------------------------- | ------------------- | ---------------------------------------------------------------------- |
-| `SITE_URL`                    | `https://artazzen.com` | Canonical site URL for SEO (sitemap, robots.txt, canonical tags)    |
-| `IMAGES_DIR`                  | `Static/images`     | Image storage path. Set to `/data/images` on Railway                   |
-| `IMPORT_ROOT`                 | `imports`           | Only server directory allowed as a source for admin filesystem imports |
-| `ADMIN_USERNAME`              | `admin`             | Basic auth username for admin                                          |
-| `ADMIN_PASSWORD`              | _(none)_            | Basic auth password (**required** for admin)                           |
-| `MY_OPENAI_API_KEY`           | _(none)_            | OpenAI API key for AI metadata                                         |
-| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-5.6-luna`      | Model for AI descriptions                                              |
-| `OPENAI_TIMEOUT_SECONDS`      | `30`                | Timeout for OpenAI calls                                               |
-| `MAX_UPLOAD_SIZE_MB`          | `50`                | Max upload file size                                                   |
-| `PORT`                        | _(uvicorn default)_ | Server port (set by Railway)                                           |
+| Variable                      | Default                | Description                                                            |
+| ----------------------------- | ---------------------- | ---------------------------------------------------------------------- |
+| `SITE_URL`                    | `https://artazzen.com` | Canonical site URL for SEO (sitemap, robots.txt, canonical tags)       |
+| `IMAGES_DIR`                  | `Static/images`        | Image storage path. Set to `/data/images` on Railway                   |
+| `IMPORT_ROOT`                 | `imports`              | Only server directory allowed as a source for admin filesystem imports |
+| `ADMIN_USERNAME`              | `admin`                | Basic auth username for admin                                          |
+| `ADMIN_PASSWORD`              | _(none)_               | Basic auth password (**required** for admin)                           |
+| `MY_OPENAI_API_KEY`           | _(none)_               | OpenAI API key for AI metadata                                         |
+| `OPENAI_IMAGE_METADATA_MODEL` | `gpt-5.6-luna`         | Model for AI descriptions                                              |
+| `OPENAI_TIMEOUT_SECONDS`      | `30`                   | Timeout for OpenAI calls                                               |
+| `MAX_UPLOAD_SIZE_MB`          | `50`                   | Max upload file size                                                   |
+| `PORT`                        | _(uvicorn default)_    | Server port (set by Railway)                                           |
 
 ## Core Principles
 

--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,7 @@ _USING_VOLUME = IMAGES_DIR != STATIC_DIR / "images"
 IMAGES_URL_PREFIX = "/images" if _USING_VOLUME else "/static/images"
 IMPORT_ROOT = Path(os.getenv("IMPORT_ROOT", BASE_DIR / "imports"))
 GALLERY_TITLE = os.getenv("GALLERY_TITLE", "Artazzen Gallery")
+SITE_URL = os.getenv("SITE_URL", "https://artazzen.com").rstrip("/")
 TEMPLATES_DIR = BASE_DIR / "templates"
 SCHEMA_PATH = BASE_DIR / "ImageSidecar.schema.json"
 CONFIG_PATH = BASE_DIR / "ai_config.json"
@@ -65,6 +66,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 templates = Jinja2Templates(directory=TEMPLATES_DIR)
+templates.env.globals["site_url"] = SITE_URL
 
 # RLock: writers that must make a read-merge-write cycle atomic (e.g. the
 # AI populate persist path) hold it across _write_sidecar, which acquires

--- a/app/routes_public.py
+++ b/app/routes_public.py
@@ -19,7 +19,7 @@ async def robots_txt():
     return (
         "User-agent: *\n"
         "Allow: /\n"
-        "Disallow: /admin/\n"
+        "Disallow: /admin\n"
         f"\nSitemap: {config.SITE_URL}/sitemap.xml\n"
     )
 

--- a/app/routes_public.py
+++ b/app/routes_public.py
@@ -1,9 +1,10 @@
 """Public gallery routes."""
 
 import logging
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse, Response
 from starlette import status
 
 from app import config, curation, sidecars
@@ -11,6 +12,43 @@ from app import config, curation, sidecars
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get("/robots.txt", response_class=PlainTextResponse)
+async def robots_txt():
+    return (
+        "User-agent: *\n"
+        "Allow: /\n"
+        "Disallow: /admin/\n"
+        f"\nSitemap: {config.SITE_URL}/sitemap.xml\n"
+    )
+
+
+@router.get("/sitemap.xml")
+async def sitemap_xml():
+    site = config.SITE_URL
+    urls = [f"  <url><loc>{site}/</loc></url>"]
+    urls.append(f"  <url><loc>{site}/collections</loc></url>")
+
+    for entry in curation.load_collections().get("collections", []):
+        slug = entry.get("id", "")
+        if slug:
+            urls.append(f"  <url><loc>{site}/collections/{quote(slug)}</loc></url>")
+
+    for item in sidecars.get_artwork_files(status_filter="approved"):
+        name = item.get("name", "")
+        if name:
+            urls.append(
+                f"  <url><loc>{site}/artwork/{quote(name)}</loc></url>"
+            )
+
+    xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        + "\n".join(urls)
+        + "\n</urlset>\n"
+    )
+    return Response(content=xml, media_type="application/xml")
 
 
 @router.get("/collections", response_class=HTMLResponse)

--- a/app/routes_public.py
+++ b/app/routes_public.py
@@ -38,9 +38,7 @@ async def sitemap_xml():
     for item in sidecars.get_artwork_files(status_filter="approved"):
         name = item.get("name", "")
         if name:
-            urls.append(
-                f"  <url><loc>{site}/artwork/{quote(name)}</loc></url>"
-            )
+            urls.append(f"  <url><loc>{site}/artwork/{quote(name)}</loc></url>")
 
     xml = (
         '<?xml version="1.0" encoding="UTF-8"?>\n'

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='css/styles.css') }}">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎨</text></svg>">
+    <link rel="canonical" href="{{ site_url }}{{ request.url.path }}">
     {% block head_extra %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}" {% block body_attrs %}{% endblock %}>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -92,7 +92,7 @@ def test_robots_txt(client: TestClient):
     response = client.get("/robots.txt")
     assert response.status_code == 200
     assert "text/plain" in response.headers["content-type"]
-    assert "Disallow: /admin/" in response.text
+    assert "Disallow: /admin" in response.text
     assert "Sitemap:" in response.text
     assert "sitemap.xml" in response.text
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -84,6 +84,48 @@ def test_artwork_detail(client: TestClient):
 
 
 # ---------------------------------------------------------------------------
+# SEO: robots.txt, sitemap.xml, canonical tags
+# ---------------------------------------------------------------------------
+
+
+def test_robots_txt(client: TestClient):
+    response = client.get("/robots.txt")
+    assert response.status_code == 200
+    assert "text/plain" in response.headers["content-type"]
+    assert "Disallow: /admin/" in response.text
+    assert "Sitemap:" in response.text
+    assert "sitemap.xml" in response.text
+
+
+def test_sitemap_xml(client: TestClient):
+    response = client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert "application/xml" in response.headers["content-type"]
+    assert "<urlset" in response.text
+    assert "<loc>" in response.text
+
+
+def test_sitemap_contains_only_approved_artworks(client: TestClient, tmp_path, monkeypatch):
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    monkeypatch.setattr(gallery_app.config, "IMAGES_DIR", image_root)
+    _add_image(image_root, "visible.jpg", status="approved")
+    _add_image(image_root, "hidden.jpg", status="pending")
+    gallery_app.curation.ensure_registries()
+
+    response = client.get("/sitemap.xml")
+    assert response.status_code == 200
+    assert "/artwork/visible.jpg" in response.text
+    assert "/artwork/hidden.jpg" not in response.text
+
+
+def test_canonical_tag_on_public_pages(client: TestClient):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert 'rel="canonical"' in response.text
+
+
+# ---------------------------------------------------------------------------
 # Security headers
 # ---------------------------------------------------------------------------
 
@@ -1229,6 +1271,8 @@ def test_all_routes_registered():
     """Every pre-split route path is still registered on main.app."""
     expected = {
         "/",
+        "/robots.txt",
+        "/sitemap.xml",
         "/artwork/{image_filename}",
         "/admin",
         "/admin/review",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,7 +105,9 @@ def test_sitemap_xml(client: TestClient):
     assert "<loc>" in response.text
 
 
-def test_sitemap_contains_only_approved_artworks(client: TestClient, tmp_path, monkeypatch):
+def test_sitemap_contains_only_approved_artworks(
+    client: TestClient, tmp_path, monkeypatch
+):
     image_root = tmp_path / "images"
     image_root.mkdir()
     monkeypatch.setattr(gallery_app.config, "IMAGES_DIR", image_root)


### PR DESCRIPTION
## Summary

- Adds `/robots.txt` route with `Disallow: /admin/` and `Sitemap:` directive pointing to the canonical site URL
- Adds `/sitemap.xml` route that dynamically lists the homepage, collections index, all collection pages, and all **approved** artworks (pending/hidden images are excluded)
- Adds `<link rel="canonical">` tag to `templates/base.html` using `SITE_URL + request.url.path` — ensures all pages signal the canonical `https://artazzen.com` origin to search engines
- Adds `SITE_URL` env var to `app/config.py` (defaults to `https://artazzen.com`), `.env.example`, and CLAUDE.md

### Context

Google Search Console shows `http://www.artazzen.com` as "not indexable." This is correct behavior — the www variant 301-redirects to the apex via Cloudflare. The sitemap, robots.txt, and canonical tags ensure Google indexes the right URLs. The user should submit `https://artazzen.com/sitemap.xml` under the **apex https property** in GSC.

**Note:** `http://www.artazzen.com` (plain HTTP on www) returns a Cloudflare 522 — this is a Cloudflare configuration issue (the www redirect rule likely only handles HTTPS). Not a code fix; needs a Cloudflare dashboard change to add an HTTP→HTTPS redirect for www, or enabling "Always Use HTTPS" if not already on.

## Test plan

- [x] `pytest` — 75 tests pass (4 new: robots.txt, sitemap.xml, approved-only filter, canonical tag)
- [x] `python manage_sidecars.py validate` — passes
- [ ] Manual: `curl http://127.0.0.1:8000/robots.txt` returns expected content
- [ ] Manual: `curl http://127.0.0.1:8000/sitemap.xml` lists only approved artworks
- [ ] Manual: View source on `/` confirms `<link rel="canonical" href="https://artazzen.com/">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sv37DdkKRdxC8DiGLcuxaV



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

