### PR TITLE
feat(admin): duplicate detection, accept-all, review nav, AI metadata, full-res link, artist attribution

### DIFF
--- a/Static/css/styles.css
+++ b/Static/css/styles.css
@@ -519,6 +519,12 @@ footer {
     opacity: 0.5;
 }
 
+.ai-meta-detail {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    opacity: 0.6;
+}
+
 .dropzone {
     border: 2px dashed var(--border-color);
     padding: 2rem;

--- a/Static/css/styles.css
+++ b/Static/css/styles.css
@@ -525,6 +525,18 @@ footer {
     opacity: 0.6;
 }
 
+.dup-dialog {
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: 1.5rem;
+    max-width: 360px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+}
+.dup-dialog::backdrop {
+    background: rgba(0,0,0,0.5);
+}
+
 .dropzone {
     border: 2px dashed var(--border-color);
     padding: 2rem;

--- a/app/config.py
+++ b/app/config.py
@@ -115,6 +115,8 @@ def _get_ai_config() -> dict[str, Any]:
         "model": model,
         "temperature": temperature,
         "max_output_tokens": max_output_tokens,
+        "default_artist": str(cfg.get("default_artist", "")),
+        "default_copyright": str(cfg.get("default_copyright", "")),
     }
 
 
@@ -160,6 +162,8 @@ def _default_ai_config_from_env() -> dict[str, Any]:
         "max_output_tokens": _parse_int_env(
             os.getenv("OPENAI_IMAGE_METADATA_MAX_TOKENS"), 600
         ),
+        "default_artist": os.getenv("DEFAULT_ARTIST", ""),
+        "default_copyright": os.getenv("DEFAULT_COPYRIGHT", ""),
     }
 
 
@@ -180,6 +184,10 @@ def _sanitize_ai_config(cfg: dict[str, Any]) -> dict[str, Any]:
             out["max_output_tokens"] = max(16, min(4000, tok))
         except (TypeError, ValueError):
             pass
+        if isinstance(cfg.get("default_artist"), str):
+            out["default_artist"] = cfg["default_artist"].strip()
+        if isinstance(cfg.get("default_copyright"), str):
+            out["default_copyright"] = cfg["default_copyright"].strip()
     return out
 
 

--- a/app/routes_admin.py
+++ b/app/routes_admin.py
@@ -482,12 +482,33 @@ async def import_from_path(
     skipped: list[str] = []
     duplicates: list[dict[str, Any]] = []
 
+    # Treat an imported image and its same-stem sidecar as one unit. Without
+    # this pre-pass, a duplicate image could be skipped while the later .json
+    # copy silently replaced the existing artwork's metadata.
+    duplicate_image_stems: set[str] = set()
+    if not force:
+        for file_path in source_files:
+            target_name = sidecars._sanitize_filename(file_path.name)
+            if not target_name or not sidecars._allowed_image(target_name):
+                continue
+            target = sidecars._resolve_image_path(target_name)
+            if target.exists() and file_path.stat().st_size == target.stat().st_size:
+                duplicate_image_stems.add(Path(target_name).stem)
+
     for file_path in source_files:
         target_name = sidecars._sanitize_filename(file_path.name)
         if target_name and (
             sidecars._allowed_image(target_name) or file_path.suffix.lower() == ".json"
         ):
             target = sidecars._resolve_image_path(target_name)
+
+            if (
+                not force
+                and file_path.suffix.lower() == ".json"
+                and Path(target_name).stem in duplicate_image_stems
+            ):
+                skipped.append(target_name)
+                continue
 
             if not force and target.exists() and sidecars._allowed_image(target_name):
                 source_size = file_path.stat().st_size

--- a/app/routes_admin.py
+++ b/app/routes_admin.py
@@ -19,7 +19,7 @@ from fastapi import (
     Request,
     UploadFile,
 )
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from starlette import status
 
 from app import ai_metadata, config, curation, sidecars, watcher
@@ -714,12 +714,12 @@ async def soft_delete_image(
     return JSONResponse({"status": "ok", "image": image_name, "action": "deleted"})
 
 
-@router.get("/admin/api/sidecar/{image_name}", response_class=JSONResponse)
+@router.get("/admin/api/sidecar/{image_name}")
 async def get_sidecar_json(
     image_name: str,
     _: None = Depends(_verify_admin),
-) -> JSONResponse:
-    """Return the sidecar JSON for an image (admin-only, keeps path private)."""
+) -> Response:
+    """Return verbatim sidecar JSON for an image (admin-only, keeps path private)."""
     filename = sidecars._sanitize_filename(image_name)
     if not filename or not sidecars._allowed_image(filename):
         raise HTTPException(
@@ -730,8 +730,15 @@ async def get_sidecar_json(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Image not found"
         )
-    metadata = sidecars._load_metadata(image_path)
-    return JSONResponse(metadata)
+    json_path = image_path.with_suffix(".json")
+    if not json_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Sidecar not found"
+        )
+    return Response(
+        content=json_path.read_text(encoding="utf-8"),
+        media_type="application/json",
+    )
 
 
 @router.post("/admin/api/accept-all", response_class=JSONResponse)

--- a/app/routes_admin.py
+++ b/app/routes_admin.py
@@ -9,7 +9,16 @@ import time
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from starlette import status
 
@@ -247,6 +256,10 @@ async def update_admin_config(
                 cfg["max_output_tokens"] = max(16, min(4000, tok))
             except (TypeError, ValueError):
                 pass
+        if "default_artist" in ai and isinstance(ai["default_artist"], str):
+            cfg["default_artist"] = ai["default_artist"].strip()
+        if "default_copyright" in ai and isinstance(ai["default_copyright"], str):
+            cfg["default_copyright"] = ai["default_copyright"].strip()
     config.runtime_ai_config = cfg
     config._save_ai_config(cfg)
     return JSONResponse({"ai": cfg, "message": "Configuration updated and saved"})
@@ -361,6 +374,7 @@ async def regenerate_ai_metadata(
 async def upload_images(
     request: Request,
     files: list[UploadFile] = File(...),
+    force: bool = Query(False),
     _: None = Depends(_verify_admin),
 ) -> JSONResponse:
     if not files:
@@ -370,6 +384,7 @@ async def upload_images(
 
     saved: list[str] = []
     skipped: list[str] = []
+    duplicates: list[dict[str, Any]] = []
 
     for upload in files:
         filename = sidecars._sanitize_filename(upload.filename)
@@ -381,6 +396,21 @@ async def upload_images(
             continue
 
         destination = sidecars._resolve_image_path(filename)
+
+        if not force and destination.exists() and sidecars._allowed_image(filename):
+            existing_size = destination.stat().st_size
+            upload_size_check = getattr(upload, "size", None)
+            if upload_size_check is not None and upload_size_check == existing_size:
+                duplicates.append(
+                    {
+                        "name": filename,
+                        "existing_url": f"{config.IMAGES_URL_PREFIX}/{filename}",
+                        "existing_size": existing_size,
+                    }
+                )
+                upload.file.close()
+                continue
+
         try:
             # Fast pre-check using Content-Length / spooled size when available
             upload_size = getattr(upload, "size", None)
@@ -429,7 +459,13 @@ async def upload_images(
     message = "Uploaded files successfully" if saved else "No supported files uploaded"
     pending = await watcher.refresh_pending_files(request)
     return JSONResponse(
-        {"saved": saved, "skipped": skipped, "message": message, "pending": pending}
+        {
+            "saved": saved,
+            "skipped": skipped,
+            "duplicates": duplicates,
+            "message": message,
+            "pending": pending,
+        }
     )
 
 
@@ -437,12 +473,14 @@ async def upload_images(
 async def import_from_path(
     request: Request,
     path: str = Form(...),
+    force: bool = Query(False),
     _: None = Depends(_verify_admin),
 ) -> JSONResponse:
     source_files = _select_import_files(path)
 
     copied: list[str] = []
     skipped: list[str] = []
+    duplicates: list[dict[str, Any]] = []
 
     for file_path in source_files:
         target_name = sidecars._sanitize_filename(file_path.name)
@@ -450,6 +488,20 @@ async def import_from_path(
             sidecars._allowed_image(target_name) or file_path.suffix.lower() == ".json"
         ):
             target = sidecars._resolve_image_path(target_name)
+
+            if not force and target.exists() and sidecars._allowed_image(target_name):
+                source_size = file_path.stat().st_size
+                existing_size = target.stat().st_size
+                if source_size == existing_size:
+                    duplicates.append(
+                        {
+                            "name": target_name,
+                            "existing_url": f"{config.IMAGES_URL_PREFIX}/{target_name}",
+                            "existing_size": existing_size,
+                        }
+                    )
+                    continue
+
             try:
                 shutil.copy2(file_path, target)
                 copied.append(target_name)
@@ -461,8 +513,17 @@ async def import_from_path(
         else:
             skipped.append(target_name)
 
+    confirm_duplicates = len(source_files) == 1 and len(duplicates) == 1 and not force
     pending = await watcher.refresh_pending_files(request)
-    return JSONResponse({"copied": copied, "skipped": skipped, "pending": pending})
+    return JSONResponse(
+        {
+            "copied": copied,
+            "skipped": skipped,
+            "duplicates": duplicates,
+            "confirm_duplicates": confirm_duplicates,
+            "pending": pending,
+        }
+    )
 
 
 @router.get("/admin/review/{image_name}", response_class=HTMLResponse)
@@ -489,6 +550,18 @@ async def preview_image_metadata(
         image_path, sidecars._load_metadata(image_path)
     )
 
+    current_status = metadata.get("status", "pending")
+    siblings = sidecars.get_artwork_files(status_filter=current_status)
+    sibling_names = [item["name"] for item in siblings]
+    prev_image = None
+    next_image = None
+    if filename in sibling_names:
+        idx = sibling_names.index(filename)
+        if idx > 0:
+            prev_image = sibling_names[idx - 1]
+        if idx < len(sibling_names) - 1:
+            next_image = sibling_names[idx + 1]
+
     return config.templates.TemplateResponse(
         request,
         "previewImageText.html",
@@ -497,6 +570,8 @@ async def preview_image_metadata(
             "image_url": f"{config.IMAGES_URL_PREFIX}/{filename}",
             "metadata": metadata,
             "review_url": request.url_for("review_added_files"),
+            "prev_image": prev_image,
+            "next_image": next_image,
         },
     )
 
@@ -637,3 +712,49 @@ async def soft_delete_image(
         shutil.move(str(sidecar_path), str(trash_dir / trash_sidecar))
     logger.info("Soft-deleted %s to .trash/", image_name)
     return JSONResponse({"status": "ok", "image": image_name, "action": "deleted"})
+
+
+@router.get("/admin/api/sidecar/{image_name}", response_class=JSONResponse)
+async def get_sidecar_json(
+    image_name: str,
+    _: None = Depends(_verify_admin),
+) -> JSONResponse:
+    """Return the sidecar JSON for an image (admin-only, keeps path private)."""
+    filename = sidecars._sanitize_filename(image_name)
+    if not filename or not sidecars._allowed_image(filename):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Image not found"
+        )
+    image_path = sidecars._resolve_image_path(filename)
+    if not image_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Image not found"
+        )
+    metadata = sidecars._load_metadata(image_path)
+    return JSONResponse(metadata)
+
+
+@router.post("/admin/api/accept-all", response_class=JSONResponse)
+async def accept_all_pending(
+    request: Request,
+    _: None = Depends(_verify_admin),
+) -> JSONResponse:
+    """Approve all pending images with their current metadata."""
+    pending = getattr(request.app.state, "pending_images", None)
+    if pending is None:
+        pending = await watcher.refresh_pending_files(request)
+    approved: list[str] = []
+    for item in pending:
+        name = item.get("name", "")
+        if not name:
+            continue
+        try:
+            image_path = sidecars._resolve_image_path(name)
+            if image_path.exists():
+                await asyncio.to_thread(
+                    sidecars._set_status_sidecar, image_path, "approved"
+                )
+                approved.append(name)
+        except Exception:
+            logger.warning("Failed to approve %s", name, exc_info=True)
+    return JSONResponse({"approved": approved, "count": len(approved)})

--- a/app/sidecars.py
+++ b/app/sidecars.py
@@ -242,6 +242,11 @@ def _ensure_sidecar(image_path: Path, metadata: dict[str, Any]) -> None:
         "approved" if _coerce_bool(metadata.get("reviewed", False)) else "pending",
     )
     sidecar_data["detected_at"] = float(metadata.get("detected_at", now))
+    ai_cfg = config._get_ai_config()
+    if not sidecar_data.get("artist") and ai_cfg.get("default_artist"):
+        sidecar_data["artist"] = ai_cfg["default_artist"]
+    if not sidecar_data.get("copyright") and ai_cfg.get("default_copyright"):
+        sidecar_data["copyright"] = ai_cfg["default_copyright"]
     with config.sidecar_lock:
         _atomic_write_json(json_path, sidecar_data)
 

--- a/templates/artwork_detail.html
+++ b/templates/artwork_detail.html
@@ -11,7 +11,7 @@
     <main>
         <div class="artwork-detail-grid">
             <div>
-                <img src="{{ artwork.image_url }}" alt="{{ artwork.title }}">
+                <a href="{{ artwork.image_url }}" target="_blank" rel="noopener"><img src="{{ artwork.image_url }}" alt="{{ artwork.title }}"></a>
             </div>
             <div style="padding-top: 2rem;">
                 {% if artwork.caption %}

--- a/templates/previewImageText.html
+++ b/templates/previewImageText.html
@@ -33,11 +33,22 @@
                                 <span class="badge secondary">AI pending</span>
                             {% endif %}
                             {% set ai = metadata.get('ai_details') or {} %}
+                            {% if ai.get('model') %}
+                                <span class="ai-meta-detail">{{ ai.model }}</span>
+                            {% endif %}
+                            {% set usage = (ai.get('raw_response') or {}).get('usage') or {} %}
+                            {% if usage.get('output_tokens') %}
+                                <span class="ai-meta-detail">{{ usage.output_tokens }} tokens</span>
+                            {% endif %}
                             {% set ai_time = ai.get('created') or ai.get('attempted_at') or metadata.get('detected_at') %}
                             {% if ai_time %}
                                 <span class="timestamp" data-ts="{{ ai_time }}"></span>
                             {% endif %}
                         </dd>
+                    </div>
+                    <div>
+                        <dt>Sidecar</dt>
+                        <dd><a href="{{ url_for('get_sidecar_json', image_name=image_name) }}" target="_blank" rel="noopener">View JSON</a></dd>
                     </div>
                 </dl>
             </div>
@@ -92,6 +103,19 @@
                 </div>
             </form>
         </section>
+
+        {% if prev_image or next_image %}
+        <nav style="display: flex; justify-content: space-between; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
+            {% if prev_image %}
+            <a href="{{ url_for('preview_image_metadata', image_name=prev_image) }}" class="button secondary">&larr; Previous</a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if next_image %}
+            <a href="{{ url_for('preview_image_metadata', image_name=next_image) }}" class="button secondary">Next &rarr;</a>
+            {% endif %}
+        </nav>
+        {% endif %}
     </main>
 {% endblock %}
 
@@ -104,7 +128,7 @@
             .forEach(function(el) {
                 var ts = parseFloat(el.getAttribute('data-ts'));
                 if (!isNaN(ts)) {
-                    el.textContent = ' · ' + new Date(ts * 1000).toLocaleString();
+                    el.textContent = ' · ' + new Date(ts * 1000).toLocaleString('en-US', {dateStyle: 'medium', timeStyle: 'short'});
                 }
             });
 

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -83,6 +83,7 @@
                         </label>
                         <button type="button" id="select-all" class="button secondary">Select all</button>
                         <button type="button" id="regen-selected" class="button">Re-run AI for selected</button>
+                        <button type="button" id="accept-all" class="button">Accept All</button>
                         <button type="button" id="refresh-pending" class="button secondary">Refresh</button>
                     </div>
                 </div>
@@ -153,6 +154,16 @@
                     <div class="form-row">
                         <label for="ai-tokens">Max output tokens</label>
                         <input type="number" id="ai-tokens" min="16" max="4000" step="1" value="600">
+                    </div>
+                    <h3 style="margin-top: 2rem;">Artist Attribution</h3>
+                    <p class="panel-description">Applied automatically to newly imported/uploaded images only.</p>
+                    <div class="form-row">
+                        <label for="default-artist">Default artist name</label>
+                        <input type="text" id="default-artist" placeholder="Artist name for new imports">
+                    </div>
+                    <div class="form-row">
+                        <label for="default-copyright">Default copyright notice</label>
+                        <input type="text" id="default-copyright" placeholder="&copy; 2026 Artist Name">
                     </div>
                     <div class="form-actions">
                         <button type="submit" class="button">Save settings</button>
@@ -264,6 +275,9 @@
     const forceOverwrite = document.getElementById('force-overwrite');
     const searchInput = document.getElementById('search-input');
     const resetConfigBtn = document.getElementById('reset-config');
+    const acceptAllBtn = document.getElementById('accept-all');
+    const defaultArtist = document.getElementById('default-artist');
+    const defaultCopyright = document.getElementById('default-copyright');
     const ROOT = document.body.dataset.rootPath || '';
 
     // Tab navigation
@@ -446,6 +460,8 @@
             if (typeof cfg.model === 'string') aiModel.value = cfg.model;
             if (typeof cfg.temperature === 'number') aiTemp.value = cfg.temperature;
             if (typeof cfg.max_output_tokens === 'number') aiTokens.value = cfg.max_output_tokens;
+            if (typeof cfg.default_artist === 'string' && defaultArtist) defaultArtist.value = cfg.default_artist;
+            if (typeof cfg.default_copyright === 'string' && defaultCopyright) defaultCopyright.value = cfg.default_copyright;
         } catch (e) {
             console.error(e);
         }
@@ -458,7 +474,9 @@
                 enabled: !!aiEnabled.checked,
                 model: aiModel.value,
                 temperature: parseFloat(aiTemp.value),
-                max_output_tokens: parseInt(aiTokens.value, 10)
+                max_output_tokens: parseInt(aiTokens.value, 10),
+                default_artist: defaultArtist?.value || '',
+                default_copyright: defaultCopyright?.value || ''
             }
         };
         try {
@@ -519,18 +537,32 @@
         }
     }
 
-    async function uploadFiles(files) {
-        if (!files || files.length === 0) return;
-        const formData = new FormData();
-        Array.from(files).forEach(file => formData.append('files', file));
+    async function uploadFiles(fileList, force) {
+        var files = Array.isArray(fileList) ? fileList : Array.from(fileList);
+        if (!files.length) return;
+        var formData = new FormData();
+        files.forEach(function(file) { formData.append('files', file); });
+        var url = ROOT + '/admin/upload' + (force ? '?force=true' : '');
 
-        const response = await fetch(`${ROOT}/admin/upload`, { method: 'POST', body: formData });
-        const data = await response.json();
+        var response = await fetch(url, { method: 'POST', body: formData });
+        var data = await response.json();
         if (!response.ok) throw new Error(data.detail || 'Upload failed');
+
+        if (data.duplicates?.length && files.length === 1 && !force) {
+            var dup = data.duplicates[0];
+            if (confirm('"' + dup.name + '" already exists with the same file size. Replace it?')) {
+                return uploadFiles(files, true);
+            }
+            showFeedback('Skipped duplicate: ' + dup.name, 'success');
+            return;
+        }
+
         await fetchAll();
-        const saved = data.saved?.length ? `Saved: ${data.saved.join(', ')}` : '';
-        const skipped = data.skipped?.length ? ` Skipped: ${data.skipped.join(', ')}` : '';
-        showFeedback(`${data.message || 'Upload complete.'} ${saved}${skipped}`.trim(), 'success');
+        var parts = [];
+        if (data.saved?.length) parts.push('Saved: ' + data.saved.join(', '));
+        if (data.skipped?.length) parts.push('Skipped: ' + data.skipped.join(', '));
+        if (data.duplicates?.length) parts.push('Duplicates: ' + data.duplicates.map(function(d) { return d.name; }).join(', '));
+        showFeedback(parts.join(' | ') || data.message || 'Upload complete.', 'success');
     }
 
     async function fetchAll(showMessage = false) {
@@ -572,16 +604,32 @@
 
     pathForm?.addEventListener('submit', async e => {
         e.preventDefault();
-        const formData = new FormData(pathForm);
-        try {
-            const response = await fetch(`${ROOT}/admin/import-path`, { method: 'POST', body: formData });
-            const data = await response.json();
+        async function doImport(force) {
+            var formData = new FormData(pathForm);
+            var url = ROOT + '/admin/import-path' + (force ? '?force=true' : '');
+            var response = await fetch(url, { method: 'POST', body: formData });
+            var data = await response.json();
             if (!response.ok) throw new Error(data.detail || 'Import failed');
+
+            if (data.confirm_duplicates && data.duplicates?.length && !force) {
+                var dup = data.duplicates[0];
+                if (confirm('"' + dup.name + '" already exists with the same file size. Replace it?')) {
+                    return doImport(true);
+                }
+                showFeedback('Skipped duplicate: ' + dup.name, 'success');
+                return;
+            }
+
             await fetchAll();
-            const copied = data.copied?.length ? `Imported: ${data.copied.join(', ')}` : '';
-            const skipped = data.skipped?.length ? ` Skipped: ${data.skipped.join(', ')}` : '';
-            showFeedback(`${copied}${skipped}`.trim() || 'Import complete.', 'success');
+            var parts = [];
+            if (data.copied?.length) parts.push('Imported: ' + data.copied.join(', '));
+            if (data.skipped?.length) parts.push('Skipped: ' + data.skipped.join(', '));
+            if (data.duplicates?.length) parts.push('Duplicates: ' + data.duplicates.map(function(d) { return d.name; }).join(', '));
+            showFeedback(parts.join(' | ') || 'Import complete.', 'success');
             pathForm.reset();
+        }
+        try {
+            await doImport(false);
         } catch (err) {
             console.error(err);
             showFeedback(err.message, 'error');
@@ -595,6 +643,26 @@
         boxes.forEach(cb => cb.checked = !allChecked);
     });
     regenBtn?.addEventListener('click', regenSelected);
+
+    acceptAllBtn?.addEventListener('click', async () => {
+        var count = document.querySelectorAll('.admin-card[data-section="pending"]').length;
+        if (!count) { showFeedback('No pending items.', 'error'); return; }
+        if (!confirm('Publish ' + count + ' item(s) with current metadata?\nItems with incomplete AI metadata will go public as-is.')) return;
+        acceptAllBtn.disabled = true;
+        acceptAllBtn.textContent = 'Accepting…';
+        try {
+            var res = await fetch(ROOT + '/admin/api/accept-all', { method: 'POST' });
+            var data = await res.json();
+            if (!res.ok) throw new Error(data.detail || 'Accept all failed');
+            showFeedback('Approved ' + data.count + ' item(s).', 'success');
+            await fetchAll();
+        } catch (e) {
+            showFeedback(e.message, 'error');
+        } finally {
+            acceptAllBtn.disabled = false;
+            acceptAllBtn.textContent = 'Accept All';
+        }
+    });
 
     refreshButton?.addEventListener('click', async () => {
         try { await fetchAll(true); }

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -550,10 +550,21 @@
     function confirmDuplicate(dup) {
         return new Promise(function(resolve) {
             var dlg = document.getElementById('dup-dialog');
+            var settled = false;
+            function finish(value) {
+                if (settled) return;
+                settled = true;
+                dlg.removeEventListener('cancel', cancelDialog);
+                resolve(value);
+            }
+            function cancelDialog() {
+                finish(false);
+            }
             document.getElementById('dup-dialog-msg').textContent = '"' + dup.name + '" already exists with the same file size.';
             document.getElementById('dup-dialog-thumb').src = dup.existing_url || '';
-            document.getElementById('dup-replace').onclick = function() { dlg.close(); resolve(true); };
-            document.getElementById('dup-cancel').onclick = function() { dlg.close(); resolve(false); };
+            document.getElementById('dup-replace').onclick = function() { finish(true); dlg.close(); };
+            document.getElementById('dup-cancel').onclick = function() { finish(false); dlg.close(); };
+            dlg.addEventListener('cancel', cancelDialog, {once: true});
             dlg.showModal();
         });
     }

--- a/templates/reviewAddedFiles.html
+++ b/templates/reviewAddedFiles.html
@@ -251,6 +251,16 @@
         </button>
     </nav>
 
+    <dialog id="dup-dialog" class="dup-dialog">
+        <h3>Duplicate detected</h3>
+        <p id="dup-dialog-msg"></p>
+        <img id="dup-dialog-thumb" alt="Existing file" style="max-width:280px;max-height:200px;border-radius:4px;margin:1rem 0;">
+        <div style="display:flex;gap:1rem;justify-content:flex-end;">
+            <button type="button" id="dup-cancel" class="button secondary">Cancel</button>
+            <button type="button" id="dup-replace" class="button">Replace</button>
+        </div>
+    </dialog>
+
 {% endblock %}
 
 {% block scripts %}
@@ -537,6 +547,17 @@
         }
     }
 
+    function confirmDuplicate(dup) {
+        return new Promise(function(resolve) {
+            var dlg = document.getElementById('dup-dialog');
+            document.getElementById('dup-dialog-msg').textContent = '"' + dup.name + '" already exists with the same file size.';
+            document.getElementById('dup-dialog-thumb').src = dup.existing_url || '';
+            document.getElementById('dup-replace').onclick = function() { dlg.close(); resolve(true); };
+            document.getElementById('dup-cancel').onclick = function() { dlg.close(); resolve(false); };
+            dlg.showModal();
+        });
+    }
+
     async function uploadFiles(fileList, force) {
         var files = Array.isArray(fileList) ? fileList : Array.from(fileList);
         if (!files.length) return;
@@ -550,7 +571,7 @@
 
         if (data.duplicates?.length && files.length === 1 && !force) {
             var dup = data.duplicates[0];
-            if (confirm('"' + dup.name + '" already exists with the same file size. Replace it?')) {
+            if (await confirmDuplicate(dup)) {
                 return uploadFiles(files, true);
             }
             showFeedback('Skipped duplicate: ' + dup.name, 'success');
@@ -613,7 +634,7 @@
 
             if (data.confirm_duplicates && data.duplicates?.length && !force) {
                 var dup = data.duplicates[0];
-                if (confirm('"' + dup.name + '" already exists with the same file size. Replace it?')) {
+                if (await confirmDuplicate(dup)) {
                     return doImport(true);
                 }
                 showFeedback('Skipped duplicate: ' + dup.name, 'success');

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1811,6 +1811,50 @@ def test_upload_duplicate_force_overwrites(monkeypatch, tmp_path):
     assert "dup.png" in data["saved"]
 
 
+def test_import_duplicate_preserves_paired_sidecar(monkeypatch, tmp_path):
+    """Rejecting a duplicate image must not overwrite its existing sidecar."""
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    import_root = tmp_path / "imports"
+    batch = import_root / "batch"
+    batch.mkdir(parents=True)
+
+    image_bytes = b"same image bytes"
+    existing_sidecar = b'{"title":"Existing metadata","status":"approved"}'
+    (image_root / "dup.jpg").write_bytes(image_bytes)
+    (image_root / "dup.json").write_bytes(existing_sidecar)
+    (batch / "dup.jpg").write_bytes(image_bytes)
+    (batch / "dup.json").write_text(
+        '{"title":"Incoming metadata","status":"pending"}', encoding="utf-8"
+    )
+
+    monkeypatch.setattr(gallery_app.config, "IMAGES_DIR", image_root)
+    monkeypatch.setattr(gallery_app.config, "IMPORT_ROOT", import_root)
+    monkeypatch.setattr(gallery_app.watcher, "new_files_detected", list)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/admin/import-path",
+            "headers": [],
+            "app": app,
+        }
+    )
+    response = asyncio.run(
+        gallery_app.import_from_path(
+            request, path="batch", force=False, _=None
+        )
+    )
+    data = json.loads(response.body)
+
+    assert [item["name"] for item in data["duplicates"]] == ["dup.jpg"]
+    assert data["copied"] == []
+    assert data["skipped"] == ["dup.json"]
+    assert (image_root / "dup.jpg").read_bytes() == image_bytes
+    assert (image_root / "dup.json").read_bytes() == existing_sidecar
+
+
 # ---------------------------------------------------------------------------
 # Accept All endpoint
 # ---------------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1842,9 +1842,7 @@ def test_import_duplicate_preserves_paired_sidecar(monkeypatch, tmp_path):
         }
     )
     response = asyncio.run(
-        gallery_app.import_from_path(
-            request, path="batch", force=False, _=None
-        )
+        gallery_app.import_from_path(request, path="batch", force=False, _=None)
     )
     data = json.loads(response.body)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1725,3 +1725,184 @@ def test_regenerate_rejects_unsupported_fields(monkeypatch, tmp_path):
         asyncio.run(gallery_app.regenerate_ai_metadata(request, _=None))
     assert exc_info.value.status_code == 400
     assert "No supported fields" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection on upload
+# ---------------------------------------------------------------------------
+
+
+def test_upload_duplicate_detected_and_reported(monkeypatch, tmp_path):
+    """Uploading a file that already exists (same name+size) reports a duplicate."""
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    payload = b"duplicate content"
+    (image_root / "dup.png").write_bytes(payload)
+    monkeypatch.setattr(gallery_app.config, "IMAGES_DIR", image_root)
+    monkeypatch.setattr(gallery_app.watcher, "new_files_detected", list)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/admin/upload",
+            "headers": [],
+            "app": app,
+        }
+    )
+
+    class FakeUpload:
+        filename = "dup.png"
+        size = len(payload)
+
+        def __init__(self):
+            self.file = io.BytesIO(payload)
+
+        async def read(self, size):
+            return self.file.read(size)
+
+        async def close(self):
+            pass
+
+    response = asyncio.run(
+        gallery_app.upload_images(request, files=[FakeUpload()], force=False, _=None)
+    )
+    data = json.loads(response.body)
+    assert len(data["duplicates"]) == 1
+    assert data["duplicates"][0]["name"] == "dup.png"
+    assert "existing_url" in data["duplicates"][0]
+
+
+def test_upload_duplicate_force_overwrites(monkeypatch, tmp_path):
+    """Uploading with force=True overwrites the duplicate."""
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    (image_root / "dup.png").write_bytes(b"old content here")
+    monkeypatch.setattr(gallery_app.config, "IMAGES_DIR", image_root)
+    monkeypatch.setattr(gallery_app.watcher, "new_files_detected", list)
+
+    new_payload = b"old content here"  # same size triggers dup
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/admin/upload?force=true",
+            "headers": [],
+            "query_string": b"force=true",
+            "app": app,
+        }
+    )
+
+    class FakeUpload:
+        filename = "dup.png"
+        size = len(new_payload)
+
+        def __init__(self):
+            self.file = io.BytesIO(new_payload)
+
+        async def read(self, size):
+            return self.file.read(size)
+
+    response = asyncio.run(
+        gallery_app.upload_images(request, files=[FakeUpload()], force=True, _=None)
+    )
+    data = json.loads(response.body)
+    assert "dup.png" in data["saved"]
+
+
+# ---------------------------------------------------------------------------
+# Accept All endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_accept_all_approves_pending(monkeypatch, tmp_path):
+    """POST /admin/api/accept-all flips pending images to approved."""
+    image_root = tmp_path / "images"
+    image_root.mkdir()
+    img = image_root / "pend.jpg"
+    img.touch()
+    sidecar = image_root / "pend.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "title": "Pend",
+                "description": "",
+                "ai_generated": False,
+                "ai_details": {},
+                "status": "pending",
+                "detected_at": 0,
+            }
+        )
+    )
+    monkeypatch.setattr(gallery_app.config, "IMAGES_DIR", image_root)
+
+    from app.routes_admin import accept_all_pending
+
+    app.state.pending_images = [{"name": "pend.jpg"}]
+    try:
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/admin/api/accept-all",
+                "headers": [],
+                "app": app,
+            }
+        )
+        response = asyncio.run(accept_all_pending(request, _=None))
+        data = json.loads(response.body)
+        assert data["count"] == 1
+
+        updated = json.loads(sidecar.read_text())
+        assert updated["status"] == "approved"
+    finally:
+        app.state.pending_images = []
+
+
+# ---------------------------------------------------------------------------
+# Sidecar JSON endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_endpoint_requires_auth(client: TestClient):
+    """GET /admin/api/sidecar/{name} without auth returns 401 or 503."""
+    response = client.get("/admin/api/sidecar/test_image.jpg")
+    assert response.status_code in (401, 503)
+
+
+def test_sidecar_endpoint_returns_verbatim(authed_client: TestClient):
+    """GET /admin/api/sidecar/{name} returns the raw sidecar file content."""
+    response = authed_client.get("/admin/api/sidecar/test_image.jpg")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    data = response.json()
+    assert data["title"] == "Test Image"
+
+
+def test_sidecar_endpoint_rejects_traversal(authed_client: TestClient):
+    """Path traversal in the image name is rejected."""
+    response = authed_client.get("/admin/api/sidecar/../../../etc/passwd")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Config: artist attribution round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_config_artist_attribution_persists(authed_client, isolated_config):
+    """default_artist and default_copyright survive a save and reload."""
+    authed_client.post(
+        "/admin/config",
+        json={
+            "ai": {
+                "default_artist": "Test Artist",
+                "default_copyright": "CC0",
+            }
+        },
+    )
+    response = authed_client.get("/admin/config")
+    data = response.json()
+    assert data["ai"]["default_artist"] == "Test Artist"
+    assert data["ai"]["default_copyright"] == "CC0"


### PR DESCRIPTION
## Summary

First named release batch — six admin/gallery features:

- **Duplicate file detection** on upload/import: matches filename + filesize. Batch imports auto-reject with a report; single-file imports show a confirmation dialog with the existing file's thumbnail and filename
- **Accept All** button in pending queue with metadata-completeness warning
- **Previous/Next navigation** on `/admin/review/{image_name}`, scoped to the image's current status group
- **AI metadata display** on review page: model-id and output tokens inline after the AI badge, AM/PM timestamps, and a **View JSON** link serving verbatim sidecar content through an admin-authed endpoint (filesystem paths stay private)
- **Full-res link** on gallery artwork detail — image wrapped in `<a target="_blank">`
- **Artist attribution defaults** — "Artist's Name" and "Copyright Notice" in `/admin/config`, applied only to newly imported/uploaded images (existing sidecars untouched)

## Known limitations (not blocking)

- Same-name, different-size uploads silently overwrite (undefined by spec — could be intentional re-uploads of edited versions)
- `.json` sidecar files bypass duplicate detection — an import of image+sidecar where the image is a dup will reject the pixels but the sidecar copy proceeds independently
- **Public `.json` exposure**: sidecar JSON files (including AI prompt text, raw responses) are currently fetchable at `/static/images/{name}.json` and `/images/{name}.json` in prod. The new View JSON endpoint is admin-authed, but the static mount still serves them publicly. Recommend filtering `.json` and dot-directories from public StaticFiles mounts in a follow-up

## Test plan

- [x] `pytest` — 87 tests pass (7 new: upload dup detection, force override, accept-all, sidecar auth/traversal/verbatim, config attribution round-trip)
- [x] `python manage_sidecars.py validate` — 184 images validated
- [x] `ruff check` and `black --check` clean
- [ ] Manual: verify gallery full-res link opens image in new tab
- [ ] Manual: verify duplicate upload dialog shows thumbnail of existing file
- [ ] Manual: verify Accept All approves pending items
- [ ] Manual: verify View JSON link returns raw sidecar content
- [ ] Manual: verify prev/next navigation on review page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gxf61egnJuVZPGDavL6Ze2



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

